### PR TITLE
Control prefill and decode batch size separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Environment Variables Added:
 |  PROF_STEP            | interger       | 5           | Control profile step                                                         |  add -e in docker run command  |
 |  PROF_PATH            | string         | /root/text-generation-inference                                   | Define profile folder  | add -e in docker run command  |
 | LIMIT_HPU_GRAPH       | True/False     | False       | Skip HPU graph usage for prefill to save memory | add -e in docker run command |
-| BATCH_BUCKET_SIZE     | integer        | 8           | Batch size will be rounded to the nearest multiple of this number. This limits the number of cached graphs | add -e in docker run command |
+| BATCH_BUCKET_SIZE     | integer        | 8           | Batch size for decode operation will be rounded to the nearest multiple of this number. This limits the number of cached graphs | add -e in docker run command |
+| PREFILL_BATCH_BUCKET_SIZE     | integer        | 4           | Batch size for prefill operation will be rounded to the nearest multiple of this number. This limits the number of cached graphs | add -e in docker run command |
 
 </div>
 

--- a/router/src/infer.rs
+++ b/router/src/infer.rs
@@ -50,11 +50,18 @@ impl Infer {
         max_concurrent_requests: usize,
         requires_padding: bool,
         max_input_length: u32,
+        max_total_tokens: u32,
         window_size: Option<u32>,
         generation_health: Arc<AtomicBool>,
     ) -> Self {
         // Infer shared state
-        let queue = Queue::new(requires_padding, max_input_length, 16, window_size);
+        let queue = Queue::new(
+            requires_padding,
+            max_input_length,
+            max_total_tokens,
+            16,
+            window_size
+        );
         let shared = Arc::new(Shared {
             batching_task: Notify::new(),
         });

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -596,6 +596,7 @@ pub async fn run(
         max_concurrent_requests,
         shard_info.requires_padding,
         max_input_length as u32,
+        max_total_tokens as u32,
         shard_info.window_size,
         generation_health,
     );


### PR DESCRIPTION
This PR allows to control prefill and decode batch size separately. It is quite important, because in general we should prefer smaller number of request in prefill operation than in decode.
Also it includes padding on output tokens during token budget calculations.