### PR TITLE
Set default value of LIMIT_HPU_GRAPH to True

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Not all features of TGI are currently supported as this is still a work in progr
 New changes are added for the current release:
 - Sharded feature with support for DeepSpeed-inference auto tensor parallelism. Also, use HPU graphs for performance improvement.
 - Torch profile.
+- Batch size bucketing for decode and prefill.
+
 
 
 Environment Variables Added:
@@ -73,12 +75,21 @@ Environment Variables Added:
 |  PROF_WARMUPSTEP      | integer        | 0           | Enable/disable profile, control profile warmup step, 0 means disable profile |  add -e in docker run command  |
 |  PROF_STEP            | interger       | 5           | Control profile step                                                         |  add -e in docker run command  |
 |  PROF_PATH            | string         | /root/text-generation-inference                                   | Define profile folder  | add -e in docker run command  |
-| LIMIT_HPU_GRAPH       | True/False     | False       | Skip HPU graph usage for prefill to save memory | add -e in docker run command |
+| LIMIT_HPU_GRAPH       | True/False     | True        | Skip HPU graph usage for prefill to save memory | add -e in docker run command |
 | BATCH_BUCKET_SIZE     | integer        | 8           | Batch size for decode operation will be rounded to the nearest multiple of this number. This limits the number of cached graphs | add -e in docker run command |
 | PREFILL_BATCH_BUCKET_SIZE     | integer        | 4           | Batch size for prefill operation will be rounded to the nearest multiple of this number. This limits the number of cached graphs | add -e in docker run command |
 
 </div>
 
+
+Maximum batch size is controlled by two arguments:
+- For prefill operation, please set `--max-prefill-total-tokens` as `bs * max-input-length`, where `bs` is your exepected maximum prefill batch size.
+- For decode operation, please set `--max-batch-total-tokens` as `bs * max-total-tokens`, where `bs` is your exepected maximum decode batch size.
+- Please note that batch size will be always padded to the nearest multiplication of `BATCH_BUCKET_SIZE` and `PREFILL_BATCH_BUCKET_SIZE`.
+
+Current limitations:
+- `LIMIT_HPU_GRAPH=False` is not supported as it causes accuracy issues.
+- Memory usage is higher than expected. Please consider using smaller batch sizes.
 
 > The license to use TGI on Habana Gaudi is the one of TGI: https://github.com/huggingface/text-generation-inference/blob/main/LICENSE
 >

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -397,7 +397,7 @@ class CausalLM(Model):
         world_size = int(os.getenv("WORLD_SIZE", "1"))
         rank = int(os.getenv("RANK"), 0)
         self.enable_hpu_graph = os.getenv("ENABLE_HPU_GRAPH", "true").lower() == "true"
-        self.limit_hpu_graph = os.getenv("LIMIT_HPU_GRAPH", "false").lower() == "true"
+        self.limit_hpu_graph = os.getenv("LIMIT_HPU_GRAPH", "true").lower() == "true"
 
         if world_size > 1:
             import habana_frameworks.torch.hpu as torch_hpu


### PR DESCRIPTION
# What does this PR do?

Set default value of LIMIT_HPU_GRAPHS as True. This will disable HPU graphs for prefill operation. It is expected to be done for larger model and/or sequences, but it also fixes the accuracy issue in continuous batching scenario.

Update README with current limitations and batch size controlling method.