### PR TITLE
Make tokenizer optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Environment Variables Added:
 | LIMIT_HPU_GRAPH       | True/False     | True       | Skip HPU graph usage for prefill to save memory, set to `True` for large sequence/decoding lengths(e.g. 300/212) | add -e in docker run command |
 | BATCH_BUCKET_SIZE     | integer        | 8           | Batch size for decode operation will be rounded to the nearest multiple of this number. This limits the number of cached graphs | add -e in docker run command |
 | PREFILL_BATCH_BUCKET_SIZE     | integer        | 4           | Batch size for prefill operation will be rounded to the nearest multiple of this number. This limits the number of cached graphs | add -e in docker run command |
-| SKIP_TOKENIZER_IN_TGI | true/false     | true        | Enable tokenizer for input/output processing | add -e in docker run command |
+| SKIP_TOKENIZER_IN_TGI | True/False     | False        | Skip tokenizer for input/output processing | add -e in docker run command |
 |  TGI_PROFILER_ENABLED | True/False     | False       | Collect high-level server tracing events          | add -e in docker run command  |
 
 </div>

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Environment Variables Added:
 | LIMIT_HPU_GRAPH       | True/False     | False       | Skip HPU graph usage for prefill to save memory | add -e in docker run command |
 | BATCH_BUCKET_SIZE     | integer        | 8           | Batch size for decode operation will be rounded to the nearest multiple of this number. This limits the number of cached graphs | add -e in docker run command |
 | PREFILL_BATCH_BUCKET_SIZE     | integer        | 4           | Batch size for prefill operation will be rounded to the nearest multiple of this number. This limits the number of cached graphs | add -e in docker run command |
+| SKIP_TOKENIZER_IN_TGI | true/false     | true        | Enable tokenizer for input/output processing | add -e in docker run command |
 
 </div>
 

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -140,9 +140,9 @@ fn main() -> Result<(), RouterError> {
 
     // Tokenizer instance
     // This will only be used to validate payloads
-    let local_path: &Path = Path::new(&tokenizer_name);
+    let local_path = Path::new(&tokenizer_name);
     let local_model = local_path.exists() && local_path.is_dir();
-    let skip_tokenizer_in_tgi = env::var("SKIP_TOKENIZER_IN_TGI").ok().map_or(false, |value| value == "true");
+    let skip_tokenizer_in_tgi = env::var("SKIP_TOKENIZER_IN_TGI").ok().map_or(false, |value| value.to_lowercase() == "true");
     let tokenizer = if skip_tokenizer_in_tgi {
         None
     } else if local_model {

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -7,6 +7,7 @@ use opentelemetry::sdk::trace::Sampler;
 use opentelemetry::sdk::Resource;
 use opentelemetry::{global, KeyValue};
 use opentelemetry_otlp::WithExportConfig;
+use std::env;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::Path;
 use std::time::Duration;
@@ -139,9 +140,12 @@ fn main() -> Result<(), RouterError> {
 
     // Tokenizer instance
     // This will only be used to validate payloads
-    let local_path = Path::new(&tokenizer_name);
+    let local_path: &Path = Path::new(&tokenizer_name);
     let local_model = local_path.exists() && local_path.is_dir();
-    let tokenizer = if local_model {
+    let skip_tokenizer_in_tgi = env::var("SKIP_TOKENIZER_IN_TGI").ok().map_or(false, |value| value == "true");
+    let tokenizer = if skip_tokenizer_in_tgi {
+        None
+    } else if local_model {
         // Load local tokenizer
         Tokenizer::from_file(local_path.join("tokenizer.json")).ok()
     } else {
@@ -162,7 +166,9 @@ fn main() -> Result<(), RouterError> {
         .block_on(async {
             init_logging(otlp_endpoint, json_output);
 
-            if tokenizer.is_none() {
+            if skip_tokenizer_in_tgi {
+                tracing::warn!("Rust input length validation disabled by environment variable");
+            } else if tokenizer.is_none() {
                 tracing::warn!(
                     "Could not find a fast tokenizer implementation for {tokenizer_name}"
                 );

--- a/server/tests/utils/test_tokens.py
+++ b/server/tests/utils/test_tokens.py
@@ -5,7 +5,6 @@ from text_generation_server.utils.tokens import (
     FinishReason,
     batch_top_tokens,
     make_tokenizer_optional,
-    get_dummy_input
 )
 from transformers import AutoTokenizer
 
@@ -78,8 +77,10 @@ def test_pass_through_tokenizer():
             padding_side="left",
             truncation_side="left",
     )
+    tokenizer.pad_token_id = 2
     make_tokenizer_optional(tokenizer)
-    input = ["1,  1724, 338,  6483,  6509, 29973", get_dummy_input(tokenizer)]
+
+    input = ["1,  1724, 338,  6483,  6509, 29973", "?"]
     tokenized_inputs = tokenizer(
         input,
         return_tensors="pt",
@@ -90,8 +91,9 @@ def test_pass_through_tokenizer():
     )
     assert tokenized_inputs['input_ids'].size() == torch.Size([2, 1024])
     assert torch.equal(tokenized_inputs['input_ids'][0][1018:], torch.tensor([1, 1724, 338, 6483, 6509, 29973]))
-    assert torch.equal(tokenized_inputs['input_ids'][1][1022:], torch.tensor([1, 1577]))
+    assert torch.equal(tokenized_inputs['input_ids'][1][1023:], torch.tensor([tokenizer.pad_token_id]))
     decoded_tokens = tokenizer.decode(tokenized_inputs["input_ids"][0], skip_special_tokens=True, clean_up_tokenization_spaces=False)
+    assert decoded_tokens.split(',')[1018:] == ['1', '1724', '338', '6483', '6509', '29973']
 
 
 if __name__ == "__main__":

--- a/server/tests/utils/test_tokens.py
+++ b/server/tests/utils/test_tokens.py
@@ -4,8 +4,10 @@ from text_generation_server.utils.tokens import (
     StoppingCriteria,
     FinishReason,
     batch_top_tokens,
+    make_tokenizer_optional,
+    get_dummy_input
 )
-
+from transformers import AutoTokenizer
 
 def test_stop_sequence_criteria():
     criteria = StopSequenceCriteria("/test;")
@@ -67,35 +69,16 @@ def test_batch_top_tokens():
     assert topn_tok_logprobs[3] == [-1, -2, -3, -3]
     assert topn_tok_logprobs[4] == [-1, -2, -3, -3, -4]
 
-from transformers import PreTrainedTokenizerBase
-class pass_through_tokenizer(PreTrainedTokenizerBase):
-    def __call__(
-        self,
-        text,
-        return_tensors,
-        padding,
-        return_token_type_ids,
-        truncation,
-        max_length
-    ):
-        assert return_tensors=="pt", "inccorrect input arguments when calling pass through tokenizer"
-        assert padding=="max_length","inccorrect input arguments when calling pass through tokenizer"
-        assert return_token_type_ids==False,"inccorrect input arguments when calling pass through tokenizer"
-        assert truncation==True,"inccorrect input arguments when calling pass through tokenizer"
-        all_tokens = [[int(i.strip()) for i in inner_text.split(',')] for inner_text in text]
-        return {"input_ids": torch.tensor([tokens + [2] * (max_length-len(tokens)) for tokens in all_tokens]),
-                "attention_mask": torch.tensor([[0] * (max_length-len(tokens)) + [1]*len(tokens) for tokens in all_tokens])}
-
-
-def get_dummy_input(tokenizer):
-    if type(tokenizer) == pass_through_tokenizer:
-        return "1, 1577"
-    else:
-        return "?"
 
 
 def test_pass_through_tokenizer():
-    tokenizer = pass_through_tokenizer()
+    tokenizer = AutoTokenizer.from_pretrained(
+            'meta-llama/Llama-2-7b-chat-hf',
+            revision=None,
+            padding_side="left",
+            truncation_side="left",
+    )
+    make_tokenizer_optional(tokenizer)
     input = ["1,  1724, 338,  6483,  6509, 29973", get_dummy_input(tokenizer)]
     tokenized_inputs = tokenizer(
         input,
@@ -105,7 +88,11 @@ def test_pass_through_tokenizer():
         truncation=True,
         max_length=1024,
     )
-    print(tokenized_inputs)
+    assert tokenized_inputs['input_ids'].size() == torch.Size([2, 1024])
+    assert torch.equal(tokenized_inputs['input_ids'][0][1018:], torch.tensor([1, 1724, 338, 6483, 6509, 29973]))
+    assert torch.equal(tokenized_inputs['input_ids'][1][1022:], torch.tensor([1, 1577]))
+    decoded_tokens = tokenizer.decode(tokenized_inputs["input_ids"][0], skip_special_tokens=True, clean_up_tokenization_spaces=False)
+
 
 if __name__ == "__main__":
     test_pass_through_tokenizer()

--- a/server/tests/utils/test_tokens.py
+++ b/server/tests/utils/test_tokens.py
@@ -66,3 +66,46 @@ def test_batch_top_tokens():
     assert topn_tok_logprobs[2] == [-1, -2, -3, -3]
     assert topn_tok_logprobs[3] == [-1, -2, -3, -3]
     assert topn_tok_logprobs[4] == [-1, -2, -3, -3, -4]
+
+from transformers import PreTrainedTokenizerBase
+class pass_through_tokenizer(PreTrainedTokenizerBase):
+    def __call__(
+        self,
+        text,
+        return_tensors,
+        padding,
+        return_token_type_ids,
+        truncation,
+        max_length
+    ):
+        assert return_tensors=="pt", "inccorrect input arguments when calling pass through tokenizer"
+        assert padding=="max_length","inccorrect input arguments when calling pass through tokenizer"
+        assert return_token_type_ids==False,"inccorrect input arguments when calling pass through tokenizer"
+        assert truncation==True,"inccorrect input arguments when calling pass through tokenizer"
+        all_tokens = [[int(i.strip()) for i in inner_text.split(',')] for inner_text in text]
+        return {"input_ids": torch.tensor([tokens + [2] * (max_length-len(tokens)) for tokens in all_tokens]),
+                "attention_mask": torch.tensor([[0] * (max_length-len(tokens)) + [1]*len(tokens) for tokens in all_tokens])}
+
+
+def get_dummy_input(tokenizer):
+    if type(tokenizer) == pass_through_tokenizer:
+        return "1, 1577"
+    else:
+        return "?"
+
+
+def test_pass_through_tokenizer():
+    tokenizer = pass_through_tokenizer()
+    input = ["1,  1724, 338,  6483,  6509, 29973", get_dummy_input(tokenizer)]
+    tokenized_inputs = tokenizer(
+        input,
+        return_tensors="pt",
+        padding="max_length",
+        return_token_type_ids=False,
+        truncation=True,
+        max_length=1024,
+    )
+    print(tokenized_inputs)
+
+if __name__ == "__main__":
+    test_pass_through_tokenizer()

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -390,8 +390,7 @@ class CausalLM(Model):
             padding_side="left",
             truncation_side="left",
         )
-        if os.getenv("MAKE_TOKENIZER_OPTIONAL", "true").lower() == "true":
-            make_tokenizer_optional(tokenizer)
+        make_tokenizer_optional(tokenizer)
 
         model_kwargs = {
             "revision": revision,

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -30,7 +30,7 @@ from text_generation_server.models.types import (
     TopTokens,
 )
 from text_generation_server.pb import generate_pb2
-from text_generation_server.utils import HeterogeneousNextTokenChooser, StoppingCriteria, Sampling, get_dummy_input, make_tokenizer_optional, is_tokenizer_transparent
+from text_generation_server.utils import HeterogeneousNextTokenChooser, StoppingCriteria, Sampling, make_tokenizer_optional, is_tokenizer_transparent
 from loguru import logger
 
 tracer = trace.get_tracer(__name__)
@@ -293,7 +293,7 @@ class CausalLMBatch(Batch):
         # this means that we cannot shift inputs to the left after a long input sequence
         # was filtered out
         new_bs = round_up(len(requests), PREFILL_BATCH_BUCKET_SIZE)
-        dummy_inputs = [get_dummy_input(tokenizer)] * (new_bs - len(requests))
+        dummy_inputs = ["?"] * (new_bs - len(requests))
         tokenized_inputs = tokenizer(
             [r.data.inputs for r in requests] + dummy_inputs,
             return_tensors="pt",

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -390,7 +390,8 @@ class CausalLM(Model):
             padding_side="left",
             truncation_side="left",
         )
-        make_tokenizer_optional(tokenizer)
+        if os.getenv("MAKE_TOKENIZER_OPTIONAL", "true").lower() == "true":
+            make_tokenizer_optional(tokenizer)
 
         model_kwargs = {
             "revision": revision,

--- a/server/text_generation_server/server.py
+++ b/server/text_generation_server/server.py
@@ -70,7 +70,7 @@ class TextGenerationService(generate_pb2_grpc.TextGenerationServiceServicer):
 
     async def Prefill(self, request, context):
         batch = self.model.batch_type.from_pb(
-            request.batch, self.model.tokenizer2, self.model.dtype, self.model.device, self.model.is_optimized_for_gaudi
+            request.batch, self.model.tokenizer, self.model.dtype, self.model.device, self.model.is_optimized_for_gaudi
         )
 
         generations, next_batch = self.model.generate_token(batch)
@@ -116,9 +116,6 @@ def serve(
     uds_path: Path,
     sharded: bool,
 ):
-    import debugpy
-    debugpy.listen(("localhost", 5678))
-    debugpy.wait_for_client()
     # Remove default handler
     logger.remove()
     logger.add(

--- a/server/text_generation_server/server.py
+++ b/server/text_generation_server/server.py
@@ -70,7 +70,7 @@ class TextGenerationService(generate_pb2_grpc.TextGenerationServiceServicer):
 
     async def Prefill(self, request, context):
         batch = self.model.batch_type.from_pb(
-            request.batch, self.model.tokenizer, self.model.dtype, self.model.device, self.model.is_optimized_for_gaudi
+            request.batch, self.model.tokenizer2, self.model.dtype, self.model.device, self.model.is_optimized_for_gaudi
         )
 
         generations, next_batch = self.model.generate_token(batch)
@@ -116,6 +116,9 @@ def serve(
     uds_path: Path,
     sharded: bool,
 ):
+    import debugpy
+    debugpy.listen(("localhost", 5678))
+    debugpy.wait_for_client()
     # Remove default handler
     logger.remove()
     logger.add(

--- a/server/text_generation_server/utils/__init__.py
+++ b/server/text_generation_server/utils/__init__.py
@@ -19,7 +19,6 @@ from text_generation_server.utils.tokens import (
     Sampling,
     Greedy,
     make_tokenizer_optional,
-    get_dummy_input,
     is_tokenizer_transparent
 )
 

--- a/server/text_generation_server/utils/__init__.py
+++ b/server/text_generation_server/utils/__init__.py
@@ -18,6 +18,9 @@ from text_generation_server.utils.tokens import (
     FinishReason,
     Sampling,
     Greedy,
+    make_tokenizer_optional,
+    get_dummy_input,
+    is_tokenizer_transparent
 )
 
 __all__ = [

--- a/server/text_generation_server/utils/tokens.py
+++ b/server/text_generation_server/utils/tokens.py
@@ -377,7 +377,13 @@ def make_tokenizer_optional(tokenizer):
             assert padding == "max_length", "inccorrect input arguments when calling TransparentTokenizer"
             assert return_token_type_ids == False, "inccorrect input arguments when calling TransparentTokenizer"
             assert truncation == True, "inccorrect input arguments when calling TransparentTokenizer"
-            all_tokens = [[int(i.strip()) for i in inner_text.split(',')]
+
+            def str_token_to_int(i):
+                if i == '?':
+                    return tokenizer.pad_token_id
+                else:
+                    return int(i)
+            all_tokens = [[str_token_to_int(i.strip()) for i in inner_text.split(',')]
                           for inner_text in text]
             return {"input_ids": torch.tensor([[2] * (max_length-len(tokens)) + tokens for tokens in all_tokens]),
                     "attention_mask": torch.tensor([[0] * (max_length-len(tokens)) + [1]*len(tokens) for tokens in all_tokens])}
@@ -399,10 +405,3 @@ def make_tokenizer_optional(tokenizer):
 
 def is_tokenizer_transparent(tokenizer):
     return hasattr(tokenizer, "is_transparent") and tokenizer.is_transparent is True
-
-
-def get_dummy_input(tokenizer):
-    if is_tokenizer_transparent(tokenizer):
-        return "1, 1577"
-    else:
-        return "?"

--- a/server/text_generation_server/utils/tokens.py
+++ b/server/text_generation_server/utils/tokens.py
@@ -391,8 +391,10 @@ def make_tokenizer_optional(tokenizer):
         ) -> str:
             return ','.join(str(i) for i in to_py_obj(token_ids))
 
-    tokenizer.__class__ = _
-    tokenizer.is_transparent = True
+    import os
+    if os.getenv("SKIP_TOKENIZER_IN_TGI", "true").lower() == "true":
+        tokenizer.__class__ = _
+        tokenizer.is_transparent = True
 
 
 def is_tokenizer_transparent(tokenizer):

--- a/server/text_generation_server/utils/tokens.py
+++ b/server/text_generation_server/utils/tokens.py
@@ -15,6 +15,7 @@ from text_generation_server.utils.logits_process import (
 )
 from text_generation_server.utils.watermark import WatermarkLogitsProcessor
 from transformers import PreTrainedTokenizerBase, RepetitionPenaltyLogitsProcessor
+from transformers.utils import to_py_obj
 
 
 class NextTokenChooser:
@@ -359,3 +360,47 @@ def batch_top_tokens(
         [idxs[:n] if req_n > 0 else [] for idxs, n, req_n in zip(top_indices, top_n_ishes, top_n_tokens)],
         [vals[:n] if req_n > 0 else [] for vals, n, req_n in zip(top_values, top_n_ishes, top_n_tokens)],
     )
+
+
+def make_tokenizer_optional(tokenizer):
+    class _(type(tokenizer)):
+        def __call__(
+            self,
+            text,
+            return_tensors,
+            padding,
+            return_token_type_ids,
+            truncation,
+            max_length
+        ):
+            assert return_tensors == "pt", "inccorrect input arguments when calling TransparentTokenizer"
+            assert padding == "max_length", "inccorrect input arguments when calling TransparentTokenizer"
+            assert return_token_type_ids == False, "inccorrect input arguments when calling TransparentTokenizer"
+            assert truncation == True, "inccorrect input arguments when calling TransparentTokenizer"
+            all_tokens = [[int(i.strip()) for i in inner_text.split(',')]
+                          for inner_text in text]
+            return {"input_ids": torch.tensor([[2] * (max_length-len(tokens)) + tokens for tokens in all_tokens]),
+                    "attention_mask": torch.tensor([[0] * (max_length-len(tokens)) + [1]*len(tokens) for tokens in all_tokens])}
+
+        def decode(
+            self,
+            token_ids,
+            skip_special_tokens: bool = False,
+            clean_up_tokenization_spaces: bool = None,
+            **kwargs,
+        ) -> str:
+            return ','.join(str(i) for i in to_py_obj(token_ids))
+
+    tokenizer.__class__ = _
+    tokenizer.is_transparent = True
+
+
+def is_tokenizer_transparent(tokenizer):
+    return hasattr(tokenizer, "is_transparent") and tokenizer.is_transparent is True
+
+
+def get_dummy_input(tokenizer):
+    if is_tokenizer_transparent(tokenizer):
+        return "1, 1577"
+    else:
+        return "?"

--- a/server/text_generation_server/utils/tokens.py
+++ b/server/text_generation_server/utils/tokens.py
@@ -385,7 +385,7 @@ def make_tokenizer_optional(tokenizer):
                     return int(i)
             all_tokens = [[str_token_to_int(i.strip()) for i in inner_text.split(',')]
                           for inner_text in text]
-            return {"input_ids": torch.tensor([[2] * (max_length-len(tokens)) + tokens for tokens in all_tokens]),
+            return {"input_ids": torch.tensor([[tokenizer.pad_token_id] * (max_length-len(tokens)) + tokens for tokens in all_tokens]),
                     "attention_mask": torch.tensor([[0] * (max_length-len(tokens)) + [1]*len(tokens) for tokens in all_tokens])}
 
         def decode(
@@ -398,7 +398,7 @@ def make_tokenizer_optional(tokenizer):
             return ','.join(str(i) for i in to_py_obj(token_ids))
 
     import os
-    if os.getenv("SKIP_TOKENIZER_IN_TGI", "true").lower() == "true":
+    if os.getenv("SKIP_TOKENIZER_IN_TGI", "false").lower() == "true":
         tokenizer.__class__ = _
         tokenizer.is_transparent = True
 


### PR DESCRIPTION
This change makes TGI respond to additional environment variable: SKIP_TOKENIZER_IN_TGI. Setting this variable to true will disable the tokenizer (TGI expects and outputs comma separated list of tokens)