### PR TITLE
Set optimum-habana branch to v1.10.0 to avoid conflicts

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -26,7 +26,7 @@ tokenizers = "^0.14.1"
 huggingface-hub = "^0.16.4"
 peft = "^0.4.0"
 deepspeed = { git = "https://github.com/HabanaAI/DeepSpeed.git", branch = "1.13.0" }
-optimum-habana =  { git = "https://github.com/huggingface/optimum-habana.git", branch = "main" }
+optimum-habana =  { git = "https://github.com/huggingface/optimum-habana.git", branch = "v1.10.0" }
 
 [tool.poetry.group.dev.dependencies]
 grpcio-tools = "*"


### PR DESCRIPTION
# What does this PR do?

Set optimum-habana package version to fixed one: v1.10.0. Downloading main branch could cause packages conflicts.