### PR TITLE
Bump rust version to 1.75.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "router/grpc-metadata",
     "launcher"
 ]
+resolver = "2"
 
 [workspace.package]
 version = "1.2.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,6 @@
 [toolchain]
+# Released on: 28 December, 2023
+# Branched from master on: 10 November, 2023
+# https://releases.rs/docs/1.75.0/
 channel = "1.75.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Bump rust toolchain version.

Commit based on https://github.com/huggingface/text-generation-inference/commit/becd09978cc1f2651ff9062ab5a64c59fd64b2ef

Cherry-picked