### PR TITLE
Enable deferred token generation (#44)

### DIFF
--- a/server/text_generation_server/server.py
+++ b/server/text_generation_server/server.py
@@ -84,7 +84,7 @@ class TextGenerationService(generate_pb2_grpc.TextGenerationServiceServicer):
         with self.profiler.record_event("external", "prefill", {"batch_size": batch.input_ids.size(0)}):
 
             with self.profiler.record_event("internal", "generate_token"):
-                generations, next_batch = self.model.generate_token(batch)
+                generations, next_batch = self.model.generate_token([batch])
             self.cache.set(next_batch)
 
             return generate_pb2.PrefillResponse(
@@ -111,14 +111,8 @@ class TextGenerationService(generate_pb2_grpc.TextGenerationServiceServicer):
             if len(batches) == 0:
                 raise ValueError("All batches are empty")
 
-            if len(batches) > 1:
-                with self.profiler.record_event("internal", "concatenate"):
-                    batch = self.model.batch_type.concatenate(batches, self.model.tokenizer.pad_token_id)
-            else:
-                batch = batches[0]
-
             with self.profiler.record_event("internal", "generate_token"):
-                generations, next_batch = self.model.generate_token(batch)
+                generations, next_batch = self.model.generate_token(batches)
             self.cache.set(next_batch)
 
             return generate_pb2.DecodeResponse(


### PR DESCRIPTION
# What does this PR do?

This PR changes the logic behind generate_token method in such a way that each call starts the model.forward() but waits for its results and completes the actual token generation in the next call to this method. This allows for pipelining the device execution with any delays caused by server<->router communication as well as token post processing logic performed on CPU.

Cherry-picked from habana-dev