### PR TITLE
Wait 2sec once shard is ready

### DIFF
--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -459,7 +459,7 @@ fn shard_manager(
     let mut envs: Vec<(OsString, OsString)> = env::vars_os().collect();
 
     // Torch Distributed Env vars
-    if  world_size == 1 {
+    if world_size == 1 {
         envs.push(("RANK".into(), rank.to_string().into()));
     }
     envs.push(("WORLD_SIZE".into(), world_size.to_string().into()));
@@ -599,6 +599,7 @@ fn shard_manager(
         // Shard is ready
         if uds.exists() && !ready {
             tracing::info!("Shard ready in {:?}", start_time.elapsed());
+            sleep(Duration::from_millis(2000));
             status_sender.send(ShardStatus::Ready).unwrap();
             ready = true;
         } else if !ready && wait_time.elapsed() > Duration::from_secs(10) {

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -142,7 +142,9 @@ fn main() -> Result<(), RouterError> {
     // This will only be used to validate payloads
     let local_path = Path::new(&tokenizer_name);
     let local_model = local_path.exists() && local_path.is_dir();
-    let skip_tokenizer_in_tgi = env::var("SKIP_TOKENIZER_IN_TGI").ok().map_or(false, |value| value.to_lowercase() == "true");
+    let skip_tokenizer_in_tgi = env::var("SKIP_TOKENIZER_IN_TGI")
+        .ok()
+        .map_or(false, |value| value.to_lowercase() == "true");
     let tokenizer = if skip_tokenizer_in_tgi {
         None
     } else if local_model {


### PR DESCRIPTION
# What does this PR do?
Adds a sleep in launcher for 2 seconds, in order to improve stability of TGI init. 
This is needed, because there are sporadic cases in which rank0 reports that the shard is ready, but some of the shards created by deepspeed (if used) are still being created - what leads to transport error.
