### PR TITLE
Wait 2sec once shard is ready to improve stability (#92)

### DIFF
--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -463,7 +463,7 @@ fn shard_manager(
     envs.push(("MAX_TOTAL_TOKENS".into(), max_total_tokens.to_string().into()));
 
     // Torch Distributed Env vars
-    if  world_size == 1 {
+    if world_size == 1 {
         envs.push(("RANK".into(), rank.to_string().into()));
     }
     envs.push(("WORLD_SIZE".into(), world_size.to_string().into()));
@@ -603,6 +603,7 @@ fn shard_manager(
         // Shard is ready
         if uds.exists() && !ready {
             tracing::info!("Shard ready in {:?}", start_time.elapsed());
+            sleep(Duration::from_millis(2000));
             status_sender.send(ShardStatus::Ready).unwrap();
             ready = true;
         } else if !ready && wait_time.elapsed() > Duration::from_secs(10) {

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -142,7 +142,9 @@ fn main() -> Result<(), RouterError> {
     // This will only be used to validate payloads
     let local_path = Path::new(&tokenizer_name);
     let local_model = local_path.exists() && local_path.is_dir();
-    let skip_tokenizer_in_tgi = env::var("SKIP_TOKENIZER_IN_TGI").ok().map_or(false, |value| value.to_lowercase() == "true");
+    let skip_tokenizer_in_tgi = env::var("SKIP_TOKENIZER_IN_TGI")
+        .ok()
+        .map_or(false, |value| value.to_lowercase() == "true");
     let tokenizer = if skip_tokenizer_in_tgi {
         None
     } else if local_model {


### PR DESCRIPTION
# What does this PR do?

Adds a sleep in launcher for 2 seconds, in order to improve stability of TGI init.
This is needed, because there are sporadic cases in which rank0 reports that the shard is ready, but some of the shards created by deepspeed (if used) are still being created - what leads to transport error.

Cherry-picked from habana-dev