### PR TITLE
Update nix version

### DIFF
--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 [dependencies]
 clap = { version = "4.4.5", features = ["derive", "env"] }
 ctrlc = { version = "3.4.1", features = ["termination"] }
-nix = "0.27.1"
+nix = "0.28.0"
 serde = { version = "1.0.188", features = ["derive"]  }
 serde_json = "1.0.107"
 tracing = "0.1.37"


### PR DESCRIPTION
Updates nix version to resolve issue while building TGI:

error[E0432]: unresolved import `nix::sys::signal::Signal`
 --> launcher/src/main.rs:2:30
  |
2 | use nix::sys::signal::{self, Signal};
  |                              ^^^^^^ no `Signal` in `sys::signal`
  |
  = help: consider importing this type alias instead:
          ctrlc::Signal

error[E0432]: unresolved import `nix::unistd::Pid`
   --> launcher/src/main.rs:3:5
    |
3   | use nix::unistd::Pid;
    |     ^^^^^^^^^^^^^^^^ no `Pid` in `unistd`
    |
note: found an item that was configured out
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nix-0.27.1/src/unistd.rs:183:12
    |
183 | pub struct Pid(pid_t);
    |            ^^^
    = note: the item is gated behind the `process` feature

error[E0425]: cannot find function `kill` in module `signal`
    --> launcher/src/main.rs:1087:13
     |
1087 |     signal::kill(Pid::from_raw(process.id() as i32), Signal::SIGTERM).unwrap();
     |             ^^^^ not found in `signal`
     |
note: found an item that was configured out
    --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nix-0.27.1/src/sys/signal.rs:974:8
     |
974  | pub fn kill<T: Into<Option<Signal>>>(pid: Pid, signal: T) -> Result<()> {
     |        ^^^^
     = note: the item is gated behind the `signal` feature