### PR TITLE
Enable server UT: test_causal_lm.py::test_batch_from_pb

### DIFF
--- a/server/tests/models/test_causal_lm.py
+++ b/server/tests/models/test_causal_lm.py
@@ -78,16 +78,16 @@ def test_batch_from_pb(default_pb_batch, default_causal_lm_batch):
 
     assert len(batch.input_ids) == size_of_padded_to_bucket 
 
-    assert batch.input_ids[0][-1] == 14402
-    assert torch.all(batch.input_ids[0][:-1] == 50256)
+    assert batch.input_ids[0][-2] == 14402
+    assert torch.all(batch.input_ids[0][:-2] == 50256)
 
-    assert batch.attention_mask[0, 0] == 1
-    assert torch.all(batch.attention_mask[0, 1:] == 0)
+    assert batch.attention_mask[0, -2] == 1
+    assert torch.all(batch.attention_mask[0, :-2] == 0)
 
     assert batch.past_key_values is None
     assert all(   
         [
-            torch.equal(input_ids, request.all_input_ids[:, 0])
+            torch.equal(input_ids, request.all_input_ids[:-10,0])
             for input_ids, request in zip(batch.input_ids, batch.requests)
         ]
     )

--- a/server/tests/models/test_causal_lm.py
+++ b/server/tests/models/test_causal_lm.py
@@ -26,7 +26,7 @@ def default_pb_request(default_pb_parameters, default_pb_stop_parameters):
         id=0,
         inputs="Test",
         prefill_logprobs=True,
-        truncate=100,
+        truncate=128, # TODO:think it through
         parameters=default_pb_parameters,
         stopping_parameters=default_pb_stop_parameters,
     )
@@ -40,7 +40,7 @@ def default_pb_batch(default_pb_request):
 @pytest.fixture
 def default_causal_lm_batch(default_pb_batch, gpt2_tokenizer):
     return CausalLMBatch.from_pb(
-        default_pb_batch, gpt2_tokenizer, torch.float32, torch.device("cpu")
+        default_pb_batch, gpt2_tokenizer, torch.float32, torch.device("hpu")
     )
 
 
@@ -54,7 +54,7 @@ def default_multi_requests_causal_lm_batch(default_pb_request, gpt2_tokenizer):
 
     batch_pb = generate_pb2.Batch(id=1, requests=[req_0, req_1], size=2)
     return CausalLMBatch.from_pb(
-        batch_pb, gpt2_tokenizer, torch.float32, torch.device("cpu")
+        batch_pb, gpt2_tokenizer, torch.float32, torch.device("hpu")
     )
 
 

--- a/server/tests/models/test_causal_lm.py
+++ b/server/tests/models/test_causal_lm.py
@@ -62,7 +62,11 @@ def test_batch_from_pb(default_pb_batch, default_causal_lm_batch):
     batch = default_causal_lm_batch
 
     assert batch.batch_id == default_pb_batch.id
-    assert batch.requests == default_pb_batch.requests
+    assert len(batch.requests) == len(default_pb_batch.requests)
+
+    for r in 0..len(default_pb_batch.requests):
+        assert batch.requests[r] == default_pb_batch.requests[r]
+#    assert batch.requests == default_pb_batch.requests
 
     assert len(batch.input_ids) == default_pb_batch.size
     assert batch.input_ids[0][-1] == 14402

--- a/server/tests/models/test_causal_lm.py
+++ b/server/tests/models/test_causal_lm.py
@@ -90,15 +90,13 @@ def test_batch_from_pb(default_pb_batch, default_causal_lm_batch):
     assert batch.past_key_values is None
     assert all(   
         [
-            torch.equal(input_ids, request.all_input_ids[:batch.input_length + 1,0])
+            torch.equal(input_ids, request.all_input_ids[:batch.input_length + 1, 0])
             for input_ids, request in zip(batch.input_ids, batch.requests)
         ]
     )
 
     assert len(batch) == default_pb_batch.size
 
-    # max_input_length is padded input tokens area , so to match truncate this max_input_length
-    # has to be increased by 1 (for output token)
     assert batch.max_input_length + 1 == default_pb_batch.requests[0].truncate
 
 

--- a/server/tests/models/test_causal_lm.py
+++ b/server/tests/models/test_causal_lm.py
@@ -78,16 +78,14 @@ def test_batch_from_pb(default_pb_batch, default_causal_lm_batch):
     assert torch.all(batch.attention_mask[0, 1:] == 0)
 
     assert batch.past_key_values is None
-
-    assert all(
+    assert all(   
         [
-            torch.equal(input_ids, all_input_ids[:, 0])
-            for input_ids, all_input_ids in zip(batch.input_ids, batch.all_input_ids)
+            torch.equal(input_ids, request.all_input_ids[:, 0])
+            for input_ids, request in zip(batch.input_ids, batch.requests)
         ]
     )
 
     assert len(batch) == default_pb_batch.size
-    assert len(batch.next_token_choosers) == len(batch.stopping_criterias) == len(batch)
 
     # max_input_length is padded input tokens area , so to match truncate this max_input_length
     # has to be increased by 1 (for output token)

--- a/server/tests/models/test_causal_lm.py
+++ b/server/tests/models/test_causal_lm.py
@@ -5,7 +5,14 @@ from copy import copy
 from transformers import AutoTokenizer
 
 from text_generation_server.pb import generate_pb2
-from text_generation_server.models.causal_lm import CausalLM, CausalLMBatch, PREFILL_BATCH_BUCKET_SIZE,PAD_SEQUENCE_TO_MULTIPLE_OF
+from text_generation_server.models.causal_lm import (
+    CausalLM,
+    CausalLMBatch,
+    PREFILL_BATCH_BUCKET_SIZE,
+    PAD_SEQUENCE_TO_MULTIPLE_OF
+)
+
+
 
 @pytest.fixture(scope="session")
 def default_causal_lm():

--- a/server/tests/models/test_causal_lm.py
+++ b/server/tests/models/test_causal_lm.py
@@ -90,7 +90,7 @@ def test_batch_from_pb(default_pb_batch, default_causal_lm_batch):
     assert batch.past_key_values is None
     assert all(   
         [
-            torch.equal(input_ids, request.all_input_ids[:batch.input_length+1,0])
+            torch.equal(input_ids, request.all_input_ids[:batch.input_length + 1,0])
             for input_ids, request in zip(batch.input_ids, batch.requests)
         ]
     )

--- a/server/tests/models/test_causal_lm.py
+++ b/server/tests/models/test_causal_lm.py
@@ -64,7 +64,7 @@ def test_batch_from_pb(default_pb_batch, default_causal_lm_batch):
     assert batch.batch_id == default_pb_batch.id
     assert len(batch.requests) == len(default_pb_batch.requests)
 
-    for r in 0..len(default_pb_batch.requests):
+    for r in range(0,len(default_pb_batch.requests)):
         assert batch.requests[r] == default_pb_batch.requests[r]
 #    assert batch.requests == default_pb_batch.requests
 

--- a/server/tests/models/test_causal_lm.py
+++ b/server/tests/models/test_causal_lm.py
@@ -82,6 +82,7 @@ def test_batch_from_pb(default_pb_batch, default_causal_lm_batch):
 
     assert batch.input_ids[0][-2] == 14402
     assert torch.all(batch.input_ids[0][:-2] == 50256)
+    assert batch.input_ids[0][-1] == 50256
 
     assert batch.attention_mask[0, -2] == 1
     assert torch.all(batch.attention_mask[0, :-2] == 0)
@@ -89,7 +90,7 @@ def test_batch_from_pb(default_pb_batch, default_causal_lm_batch):
     assert batch.past_key_values is None
     assert all(   
         [
-            torch.equal(input_ids, request.all_input_ids[:-10,0])
+            torch.equal(input_ids, request.all_input_ids[:batch.input_length+1,0])
             for input_ids, request in zip(batch.input_ids, batch.requests)
         ]
     )

--- a/server/tests/models/test_causal_lm.py
+++ b/server/tests/models/test_causal_lm.py
@@ -86,12 +86,12 @@ def test_batch_from_pb(default_pb_batch, default_causal_lm_batch):
         ]
     )
 
-    assert batch.input_lengths == [1]
-
     assert len(batch) == default_pb_batch.size
     assert len(batch.next_token_choosers) == len(batch.stopping_criterias) == len(batch)
 
-    assert batch.max_input_length == batch.input_lengths[0]
+    # max_input_length is padded input tokens area , so to match truncate this max_input_length
+    # has to be increased by 1 (for output token)
+    assert batch.max_input_length + 1 == default_pb_batch.requests[0].truncate
 
 
 def test_batch_concatenate_no_prefill(default_causal_lm_batch):

--- a/server/tests/models/test_causal_lm.py
+++ b/server/tests/models/test_causal_lm.py
@@ -5,7 +5,7 @@ from copy import copy
 from transformers import AutoTokenizer
 
 from text_generation_server.pb import generate_pb2
-from text_generation_server.models.causal_lm import CausalLM, CausalLMBatch, PREFILL_BATCH_BUCKET_SIZE
+from text_generation_server.models.causal_lm import CausalLM, CausalLMBatch, PREFILL_BATCH_BUCKET_SIZE,PAD_SEQUENCE_TO_MULTIPLE_OF
 
 @pytest.fixture(scope="session")
 def default_causal_lm():
@@ -25,7 +25,7 @@ def default_pb_request(default_pb_parameters, default_pb_stop_parameters):
         id=0,
         inputs="Test",
         prefill_logprobs=True,
-        truncate=128, # TODO:think it through
+        truncate=PAD_SEQUENCE_TO_MULTIPLE_OF,
         parameters=default_pb_parameters,
         stopping_parameters=default_pb_stop_parameters,
     )

--- a/server/tests/models/test_causal_lm.py
+++ b/server/tests/models/test_causal_lm.py
@@ -1,3 +1,5 @@
+# Copyright (C) 2024 Habana Labs, Ltd. an Intel Company.
+
 import pytest
 import torch
 


### PR DESCRIPTION
This PR is enabling and adapting server UT: test_causal_lm.py::test_batch_from_pb to Intel's Gaudi

This is a first in a series of PRs enabling server unit tests.

@kdamaszk , @sfraczek please review