### PR TITLE
Updated kv cache for starcoder

### DIFF
--- a/server/tests/models/test_starcoder.py
+++ b/server/tests/models/test_starcoder.py
@@ -1,0 +1,376 @@
+# Copyright (C) 2024 Habana Labs, Ltd. an Intel Company.
+
+import pytest
+import torch
+
+from copy import copy
+from transformers import AutoTokenizer
+
+from text_generation_server.pb import generate_pb2
+from text_generation_server.models import get_model
+from text_generation_server.models.starcoder import StarCoderCausalLMBatch
+from text_generation_server.models.causal_lm import (
+    CausalLMBatch,
+    PREFILL_BATCH_BUCKET_SIZE,
+    PAD_SEQUENCE_TO_MULTIPLE_OF,
+    MAX_TOTAL_TOKENS,
+    BATCH_BUCKET_SIZE,
+)
+from text_generation_server.utils import weight_hub_files, download_weights
+from text_generation_server.models.starcoder import StarCoderCausalLMBatch, STARCODER
+PAD_TOKEN=0
+
+
+@pytest.fixture(scope="session")
+def default_starcoder():
+    return get_model("bigcode/starcoder", None, None, None, None)
+
+
+@pytest.fixture(scope="session")
+def default_tokenizer(default_starcoder):
+    default_starcoder.tokenizer.pad_token_id = PAD_TOKEN
+    return default_starcoder.tokenizer
+
+
+@pytest.fixture
+def default_pb_request(default_pb_parameters, default_pb_stop_parameters):
+    return generate_pb2.Request(
+        id=0,
+        inputs="Test",
+        prefill_logprobs=True,
+        truncate=PAD_SEQUENCE_TO_MULTIPLE_OF,
+        parameters=default_pb_parameters,
+        stopping_parameters=default_pb_stop_parameters,
+    )
+
+
+@pytest.fixture
+def default_pb_batch(default_pb_request):
+    return generate_pb2.Batch(id=0, requests=[default_pb_request], size=1)
+
+
+@pytest.fixture
+def default_starcoder_batch(default_pb_batch, default_tokenizer):
+    return StarCoderCausalLMBatch.from_pb(
+        default_pb_batch, default_tokenizer, torch.float32, torch.device("hpu")
+    )
+
+
+@pytest.fixture
+def default_multi_requests_starcoder_batch(default_pb_request, default_tokenizer):
+    req_0 = copy(default_pb_request)
+    req_0.id = 1
+    req_1 = default_pb_request
+    req_1.id = 2
+    req_1.stopping_parameters.max_new_tokens = 5
+
+    batch_pb = generate_pb2.Batch(id=1, requests=[req_0, req_1], size=2)
+    return StarCoderCausalLMBatch.from_pb(
+        batch_pb, default_tokenizer, torch.float32, torch.device("hpu")
+    )
+
+
+def test_starcoder_batch_type(default_starcoder):
+    assert default_starcoder.batch_type == StarCoderCausalLMBatch
+
+
+def test_batch_from_pb(default_pb_batch, default_starcoder_batch):
+    batch = default_starcoder_batch
+
+    assert batch.batch_id == default_pb_batch.id
+    assert len(batch.requests) == len(default_pb_batch.requests)
+
+    for r in range(0,len(default_pb_batch.requests)):
+        assert batch.requests[r].data == default_pb_batch.requests[r]
+
+    # For Gaudi we are adding padding of multiplication of bucket size
+    size_of_padded_to_bucket = ((default_pb_batch.size + PREFILL_BATCH_BUCKET_SIZE - 1) // PREFILL_BATCH_BUCKET_SIZE) * PREFILL_BATCH_BUCKET_SIZE
+
+    assert len(batch.input_ids) == size_of_padded_to_bucket
+    assert batch.input_ids.shape == torch.Size([4, 128])
+
+    assert batch.input_ids[0][-2] == 1006
+    assert batch.input_ids[1][-2] == 49
+    assert batch.input_ids[2][-2] == 49
+    assert batch.attention_mask[0][-2] == 1
+    assert batch.attention_mask[1][-2] == 1
+    assert batch.attention_mask[2][-2] == 1
+    assert torch.all(batch.attention_mask[0, :-3] == 0)
+
+    assert batch.past_key_values is None
+    assert all(
+        [
+            torch.equal(input_ids, request.all_input_ids[:batch.input_length + 1, 0])
+            for input_ids, request in zip(batch.input_ids, batch.requests)
+        ]
+    )
+
+    assert len(batch) == default_pb_batch.size
+
+    assert batch.max_input_length + 1 == default_pb_batch.requests[0].truncate
+
+
+def test_starcoder_generate_token(default_starcoder, default_starcoder_batch):
+
+    sequence_length = len(default_starcoder_batch.requests[0].all_input_ids)
+    generations, next_batch, _ = default_starcoder.generate_token([default_starcoder_batch])
+    padding = next_batch.requests[0].stopping_criteria.max_new_tokens
+
+    assert isinstance(next_batch, StarCoderCausalLMBatch)
+    assert len(next_batch.attention_mask[0]) == PAD_SEQUENCE_TO_MULTIPLE_OF
+    assert next_batch.requests[0].all_input_ids[-padding-2] == 1006
+
+    assert torch.all(next_batch.requests[0].all_input_ids[-padding-1:] == PAD_TOKEN)
+    assert torch.all(next_batch.requests[0].all_input_ids[:-padding-3] == PAD_TOKEN)
+
+    generations, next_batch, _ = default_starcoder.generate_token([default_starcoder_batch])
+    assert torch.all(next_batch.attention_mask[0][PAD_SEQUENCE_TO_MULTIPLE_OF-2:PAD_SEQUENCE_TO_MULTIPLE_OF] == 1)
+    assert torch.all(next_batch.attention_mask[0][:PAD_SEQUENCE_TO_MULTIPLE_OF-3] == 0)
+    assert torch.all(next_batch.attention_mask[0][PAD_SEQUENCE_TO_MULTIPLE_OF+1:] == 0)
+
+    assert next_batch.requests[0].all_input_ids[-padding-2] == 1006
+    assert next_batch.requests[0].all_input_ids[-padding-1] == 26
+    assert torch.all(next_batch.requests[0].all_input_ids[-padding:] == PAD_TOKEN)
+    assert torch.all(next_batch.requests[0].all_input_ids[:-padding-3] == PAD_TOKEN)
+
+    assert next_batch.input_length == PAD_SEQUENCE_TO_MULTIPLE_OF
+    assert next_batch.max_input_length == next_batch.input_length
+
+    assert next_batch.past_key_values is not None
+    assert all(
+        [p[0].shape == (MAX_TOTAL_TOKENS, 256) for p in next_batch.past_key_values]
+    )
+    assert all(
+        [p[1].shape == (MAX_TOTAL_TOKENS, 256) for p in next_batch.past_key_values]
+    )
+    assert all([generation.generated_text is None for generation in generations])
+    assert all([len(generation.prefill_tokens) == PAD_SEQUENCE_TO_MULTIPLE_OF-1 for generation in generations])
+    assert all([generation.tokens.token_ids[0] == 26 for generation in generations])
+    assert all([generation.tokens.texts[0] == "(" for generation in generations])
+    assert generations[0].request_id == 0
+
+
+def test_starcoder_generate_token_completion(
+    default_starcoder, default_starcoder_batch
+):
+
+    next_batch = default_starcoder_batch
+    generations, next_batch, _ = default_starcoder.generate_token([next_batch])
+
+    for _ in range(default_starcoder_batch.requests[0].stopping_criteria.max_new_tokens - 1):
+        generations, next_batch, _ = default_starcoder.generate_token([next_batch])
+        assert len(generations) == len(next_batch)
+
+    generations, next_batch, _ = default_starcoder.generate_token([next_batch])
+
+    assert next_batch is None
+
+    assert len(generations) == 1
+    assert generations[0].generated_text.text == '(self):\n        """\n        Test that the test'
+    assert generations[0].request_id == default_starcoder_batch.requests[0].data.id
+    assert (
+        generations[0].generated_text.generated_tokens
+        == default_starcoder_batch.requests[0].stopping_criteria.max_new_tokens
+    )
+
+
+def test_starcoder_generate_token_completion_multi(
+    default_starcoder, default_multi_requests_starcoder_batch
+):
+    next_batch = default_multi_requests_starcoder_batch
+    generations, next_batch, _ = default_starcoder.generate_token([next_batch])
+
+    for i in range(
+        default_multi_requests_starcoder_batch.requests[1].stopping_criteria.max_new_tokens - 1
+    ):
+        generations, next_batch, _ = default_starcoder.generate_token([next_batch])
+        assert len(generations) == len(next_batch)
+
+    generations, next_batch, _ = default_starcoder.generate_token([next_batch])
+    assert next_batch is not None
+
+    assert len(generations) == 2
+    assert generations[1].generated_text.text == '(self):\n        """'
+    assert (
+        generations[1].request_id
+        == default_multi_requests_starcoder_batch.requests[1].data.id
+    )
+    assert (
+        generations[1].generated_text.generated_tokens
+        == default_multi_requests_starcoder_batch.requests[1].stopping_criteria.max_new_tokens
+    )
+
+    next_batch = next_batch.filter([next_batch.requests[0].data.id])
+
+    for _ in range(
+        default_multi_requests_starcoder_batch.requests[0].stopping_criteria.max_new_tokens - default_multi_requests_starcoder_batch.requests[1].stopping_criteria.max_new_tokens - 1
+    ):
+        generations, next_batch, _ = default_starcoder.generate_token([next_batch])
+        assert len(generations) == len(next_batch)
+
+    generations, next_batch, _ = default_starcoder.generate_token([next_batch])
+
+    assert next_batch is None
+
+    assert len(generations) == 1
+    assert generations[0].generated_text.text == '(self):\n        """\n        Test that the test'
+    assert (
+        generations[0].request_id
+        == default_multi_requests_starcoder_batch.requests[0].data.id
+    )
+    assert (
+        generations[0].generated_text.generated_tokens
+        == default_multi_requests_starcoder_batch.requests[0].stopping_criteria.max_new_tokens
+    )
+
+
+def test_batch_concatenate(
+    default_starcoder, default_starcoder_batch, default_multi_requests_starcoder_batch
+):
+    next_batch_0 = default_starcoder_batch
+    _, next_batch_0, _ = default_starcoder.generate_token([next_batch_0])
+    _, next_batch_0, _ = default_starcoder.generate_token([next_batch_0])
+    _, next_batch_0, _ = default_starcoder.generate_token([next_batch_0])
+
+    next_batch_1 = default_multi_requests_starcoder_batch
+    _, next_batch_1, _ = default_starcoder.generate_token([next_batch_1])
+    _, next_batch_1, _ = default_starcoder.generate_token([next_batch_1])
+
+    # Clone past_key_values before concatenating to compare after,
+    # because they are removed from the concatenated batches
+    next_batch_0_past_key_values = [x.clone() for x in next_batch_0.past_key_values]
+    next_batch_1_past_key_values = [x.clone() for x in next_batch_1.past_key_values]
+
+    next_batch = StarCoderCausalLMBatch.concatenate([next_batch_0, next_batch_1])
+
+    assert torch.equal(next_batch.requests[0].all_input_ids, next_batch_0.requests[0].all_input_ids)
+    assert torch.equal(next_batch.requests[1].all_input_ids, next_batch_1.requests[0].all_input_ids)
+    assert torch.equal(next_batch.requests[2].all_input_ids, next_batch_1.requests[1].all_input_ids)
+
+
+    assert torch.all(
+            next_batch.attention_mask[0:2, -next_batch.right_padding - 2: -next_batch.right_padding] == 1
+    )
+    assert torch.all(
+            next_batch.attention_mask[2, -next_batch.right_padding - 3: -next_batch.right_padding] == 1
+    )
+    assert torch.all(
+            next_batch.attention_mask[3, -next_batch.right_padding - 2: -next_batch.right_padding] == 1
+    )
+
+    assert torch.all(
+        next_batch.attention_mask[0:2, :-next_batch.right_padding-2] == 0)
+    assert torch.all(
+        next_batch.attention_mask[2, :-next_batch.right_padding-4] == 0)
+    assert torch.all(
+        next_batch.attention_mask[3, :-next_batch.right_padding-3] == 0)
+
+    assert next_batch.batch_id == 0
+    assert next_batch.input_ids[0,-next_batch.right_padding - 2] == 1006
+    assert next_batch.input_ids[0,-next_batch.right_padding - 1] == 26
+
+    assert next_batch.max_input_length == 129
+
+    assert torch.all(next_batch.input_ids[0,-next_batch.right_padding:] == PAD_TOKEN)
+    assert torch.all(next_batch.input_ids[1,-next_batch.right_padding:] == PAD_TOKEN)
+    assert torch.all(next_batch.input_ids[2,-next_batch.right_padding:] == PAD_TOKEN)
+    assert torch.all(next_batch.input_ids[3,-next_batch.right_padding:] == PAD_TOKEN)
+
+    assert next_batch.input_length == PAD_SEQUENCE_TO_MULTIPLE_OF  +1
+    assert next_batch.max_input_length == PAD_SEQUENCE_TO_MULTIPLE_OF + 1
+
+    assert next_batch.requests[0] == next_batch_0.requests[0]
+    assert next_batch.requests[1:] == next_batch_1.requests
+
+    assert next_batch.requests[0].stopping_criteria == next_batch_0.requests[0].stopping_criteria
+    assert next_batch.requests[1].stopping_criteria == next_batch_1.requests[0].stopping_criteria
+    assert next_batch.requests[2].stopping_criteria == next_batch_1.requests[1].stopping_criteria
+
+    assert next_batch.past_key_values is not None
+
+    assert all([p[0].shape == (2048, 256) for p in next_batch.past_key_values])
+    assert all([p[1].shape == (2048, 256) for p in next_batch.past_key_values])
+
+    assert next_batch.past_key_values is not None
+
+    for i, past in enumerate(next_batch.past_key_values):
+        assert torch.equal(next_batch_0_past_key_values[i][0,0,0:128], past[0][1:129][0, 0:128])
+        assert torch.equal(next_batch_0_past_key_values[i][0,1,0:128], past[1][1:129][0, 0:128])
+        assert torch.equal(
+            next_batch_1_past_key_values[i][:, :, 0:1][0][0][0], past[0][1:, :][0][0]
+        )
+
+        assert torch.equal(
+            next_batch_1_past_key_values[i][1:, :, 0:1][0][0][0], past[1][1:, :][0][0]
+        )
+
+    generations, next_batch, _ = default_starcoder.generate_token([next_batch])
+
+    for _ in range(
+        default_multi_requests_starcoder_batch.requests[1].stopping_criteria.max_new_tokens - 2
+    ):
+        generations, next_batch, _ = default_starcoder.generate_token([next_batch])
+        assert len(generations) == len(next_batch)
+
+    generations, next_batch, _ = default_starcoder.generate_token([next_batch])
+    assert next_batch is not None
+
+    assert len(generations) == 3
+    assert generations[2].generated_text.text == '(self):\n        """'
+
+    assert (
+        generations[2].request_id
+        == default_multi_requests_starcoder_batch.requests[1].data.id
+    )
+    assert (
+        generations[2].generated_text.generated_tokens
+        == default_multi_requests_starcoder_batch.requests[1].stopping_criteria.max_new_tokens
+    )
+
+    next_batch = next_batch.filter(
+        [next_batch.requests[0].data.id, next_batch.requests[1].data.id]
+    )
+
+    for _ in range(
+        default_starcoder_batch.requests[0].stopping_criteria.max_new_tokens
+        - default_multi_requests_starcoder_batch.requests[1].stopping_criteria.max_new_tokens
+        - 2
+    ):
+        generations, next_batch, _ = default_starcoder.generate_token([next_batch])
+        assert len(generations) == len(next_batch)
+
+    generations, next_batch, _ = default_starcoder.generate_token([next_batch])
+    assert next_batch is not None
+
+    assert len(generations) == 2
+    assert generations[0].generated_text.text == '(self):\n        """\n        Test that the test'
+    assert generations[0].request_id == default_starcoder_batch.requests[0].data.id
+    assert (
+        generations[0].generated_text.generated_tokens
+        == default_starcoder_batch.requests[0].stopping_criteria.max_new_tokens
+    )
+
+    next_batch = next_batch.filter([next_batch.requests[1].data.id])
+
+    for _ in range(
+        default_multi_requests_starcoder_batch.requests[0].stopping_criteria.max_new_tokens
+        - default_starcoder_batch.requests[0].stopping_criteria.max_new_tokens
+        - default_multi_requests_starcoder_batch.requests[1].stopping_criteria.max_new_tokens
+        - 4
+    ):
+        generations, next_batch, _ = default_starcoder.generate_token([next_batch])
+        assert len(generations) == len(next_batch)
+
+    generations, next_batch, _ = default_starcoder.generate_token([next_batch])
+    assert next_batch is None
+
+    assert len(generations) == 1
+    assert generations[0].generated_text.text == '(self):\n        """\n        Test that the test'
+    assert (
+        generations[0].request_id
+        == default_multi_requests_starcoder_batch.requests[0].data.id
+    )
+    assert (
+        generations[0].generated_text.generated_tokens
+        == default_multi_requests_starcoder_batch.requests[0].stopping_criteria.max_new_tokens
+    )

--- a/server/tests/models/test_starcoder.py
+++ b/server/tests/models/test_starcoder.py
@@ -4,20 +4,16 @@ import pytest
 import torch
 
 from copy import copy
-from transformers import AutoTokenizer
 
 from text_generation_server.pb import generate_pb2
 from text_generation_server.models import get_model
 from text_generation_server.models.starcoder import StarCoderCausalLMBatch
 from text_generation_server.models.causal_lm import (
-    CausalLMBatch,
     PREFILL_BATCH_BUCKET_SIZE,
     PAD_SEQUENCE_TO_MULTIPLE_OF,
     MAX_TOTAL_TOKENS,
     BATCH_BUCKET_SIZE,
 )
-from text_generation_server.utils import weight_hub_files, download_weights
-from text_generation_server.models.starcoder import StarCoderCausalLMBatch, STARCODER
 PAD_TOKEN=0
 
 

--- a/server/text_generation_server/models/__init__.py
+++ b/server/text_generation_server/models/__init__.py
@@ -14,8 +14,7 @@ from text_generation_server.utils.speculate import get_speculate, set_speculate
 from text_generation_server.models.model import Model
 from text_generation_server.models.causal_lm import CausalLM
 from text_generation_server.models.bloom import BLOOM
-from text_generation_server.models.santacoder import SantaCoder
-from text_generation_server.models.starcoder import STARCODER
+from text_generation_server.models.starcoder import StarCoder
 
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
 
@@ -87,7 +86,7 @@ def get_model(
     model_type = config_dict["model_type"]
 
     if model_type == "gpt_bigcode":
-        return STARCODER(model_id, revision, dtype)
+        return StarCoder(model_id, revision, dtype)
 
     if model_type == "bloom":
         return BLOOM(

--- a/server/text_generation_server/models/__init__.py
+++ b/server/text_generation_server/models/__init__.py
@@ -15,6 +15,7 @@ from text_generation_server.models.model import Model
 from text_generation_server.models.causal_lm import CausalLM
 from text_generation_server.models.bloom import BLOOM
 from text_generation_server.models.santacoder import SantaCoder
+from text_generation_server.models.starcoder import STARCODER
 
 from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
 
@@ -86,13 +87,7 @@ def get_model(
     model_type = config_dict["model_type"]
 
     if model_type == "gpt_bigcode":
-        return SantaCoder(
-            model_id,
-            revision,
-            use_medusa=use_medusa,
-            dtype=dtype,
-            trust_remote_code=trust_remote_code,
-        )
+        return STARCODER(model_id, revision, dtype)
 
     if model_type == "bloom":
         return BLOOM(

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -653,10 +653,6 @@ class CausalLM(Model):
         self.enable_hpu_graph = os.getenv("ENABLE_HPU_GRAPH", "true").lower() == "true"
         self.limit_hpu_graph = os.getenv("LIMIT_HPU_GRAPH", "false").lower() == "true"
 
-        # Bypasses runtime error "Empty tensor optional" with hpu graphs
-        if model.config.model_type == "gpt_bigcode":
-            assert self.enable_hpu_graph == False, "HPU graphs are not supported with Starcoder model! Please use ENABLE_HPU_GRAPH=False flag"
-
         model = remove_kv_cache_from_output(model)
         if self.enable_hpu_graph:
             from habana_frameworks.torch.hpu import wrap_in_hpu_graph

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -672,6 +672,11 @@ class CausalLM(Model):
 
         self.enable_hpu_graph = os.getenv("ENABLE_HPU_GRAPH", "true").lower() == "true"
         self.limit_hpu_graph = os.getenv("LIMIT_HPU_GRAPH", "false").lower() == "true"
+
+        # Bypasses runtime error "Empty tensor optional" with hpu graphs
+        if model.config.model_type == "gpt_bigcode":
+            assert self.enable_hpu_graph == False, "HPU graphs are not supported with Starcoder model! Please use ENABLE_HPU_GRAPH=False flag"
+
         model = remove_kv_cache_from_output(model)
         if self.enable_hpu_graph:
             from habana_frameworks.torch.hpu import wrap_in_hpu_graph

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -652,7 +652,6 @@ class CausalLM(Model):
 
         self.enable_hpu_graph = os.getenv("ENABLE_HPU_GRAPH", "true").lower() == "true"
         self.limit_hpu_graph = os.getenv("LIMIT_HPU_GRAPH", "false").lower() == "true"
-
         model = remove_kv_cache_from_output(model)
         if self.enable_hpu_graph:
             from habana_frameworks.torch.hpu import wrap_in_hpu_graph

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -592,26 +592,6 @@ class CausalLMBatch(Batch):
         max_total_tokens = self.attention_mask.size(1)
         return len(self.requests) * max_total_tokens
 
-@dataclass
-class CausalLMBatchGPTBigCode(CausalLMBatch):
-    past_key_values: Optional[List[torch.Tensor]]
-
-    def detach_kv_cache(self):
-        past_keys = []
-        past_values = []
-        last_dim = int(self.past_key_values[0].size(dim=-1)/2)
-        for key_value in self.past_key_values:
-            past_keys.append(key_value.split((last_dim, last_dim), dim=-1)[0])
-            past_values.append(key_value.split((last_dim, last_dim), dim=-1)[1])
-        del self.past_key_values
-
-        return past_keys, past_values
-
-    def attach_kv_cache(self, past_keys, past_values):
-        self.past_key_values = []
-        for key_tensor, value_tensor in zip(past_keys, past_values):
-            self.past_key_values.append(torch.cat((key_tensor, value_tensor), dim = -1))
-
 
 class CausalLM(Model):
     def __init__(
@@ -843,8 +823,6 @@ class CausalLM(Model):
 
     @property
     def batch_type(self) -> Type[CausalLMBatch]:
-        if self.model.config.model_type == "gpt_bigcode":
-            return CausalLMBatchGPTBigCode
         return CausalLMBatch
 
     def decode(self, generated_ids: List[int]) -> str:

--- a/server/text_generation_server/models/starcoder.py
+++ b/server/text_generation_server/models/starcoder.py
@@ -1,6 +1,7 @@
 from loguru import logger
 import torch
 from dataclasses import dataclass
+import os
 from typing import List, Optional, Type
 
 from text_generation_server.models import CausalLM
@@ -34,15 +35,16 @@ class STARCODER(CausalLM):
         revision: Optional[str] = None,
         dtype: Optional[torch.dtype] = None,
     ):
+
+        # Bypasses runtime error "Empty tensor optional" with hpu graphs
+        os.environ["ENABLE_HPU_GRAPH"] = "false"
+        logger.warning("Disabling HPU graphs as they are not supported with Starcoder model!")
+
         super(STARCODER, self).__init__(
             model_id=model_id,
             revision=revision,
             dtype=dtype,
         )
-
-        # Bypasses runtime error "Empty tensor optional" with hpu graphs
-        self.enable_hpu_graph = False
-        logger.warning("Disabling HPU graphs as they are not supported with Starcoder model!")
 
     @property
     def batch_type(self) -> Type[CausalLMBatch]:

--- a/server/text_generation_server/models/starcoder.py
+++ b/server/text_generation_server/models/starcoder.py
@@ -1,0 +1,44 @@
+import torch
+from dataclasses import dataclass
+from typing import List, Optional, Type
+
+from text_generation_server.models import CausalLM
+from text_generation_server.models.causal_lm import CausalLMBatch
+
+
+@dataclass
+class StarCoderCausalLMBatch(CausalLMBatch):
+    past_key_values: Optional[List[torch.Tensor]]
+
+    def detach_kv_cache(self):
+        past_keys = []
+        past_values = []
+        last_dim = int(self.past_key_values[0].size(dim=-1)/2)
+        for key_value in self.past_key_values:
+            past_keys.append(key_value.split((last_dim, last_dim), dim=-1)[0])
+            past_values.append(key_value.split((last_dim, last_dim), dim=-1)[1])
+        del self.past_key_values
+
+        return past_keys, past_values
+
+    def attach_kv_cache(self, past_keys, past_values):
+        self.past_key_values = [
+            torch.cat((key, value), dim=-1) for key, value in zip(past_keys, past_values)]
+
+
+class STARCODER(CausalLM):
+    def __init__(
+        self,
+        model_id: str,
+        revision: Optional[str] = None,
+        dtype: Optional[torch.dtype] = None,
+    ):
+        super(STARCODER, self).__init__(
+            model_id=model_id,
+            revision=revision,
+            dtype=dtype,
+        )
+
+    @property
+    def batch_type(self) -> Type[CausalLMBatch]:
+        return StarCoderCausalLMBatch

--- a/server/text_generation_server/models/starcoder.py
+++ b/server/text_generation_server/models/starcoder.py
@@ -28,7 +28,7 @@ class StarCoderCausalLMBatch(CausalLMBatch):
             torch.cat((key, value), dim=-1) for key, value in zip(past_keys, past_values)]
 
 
-class STARCODER(CausalLM):
+class StarCoder(CausalLM):
     def __init__(
         self,
         model_id: str,
@@ -40,7 +40,7 @@ class STARCODER(CausalLM):
         os.environ["ENABLE_HPU_GRAPH"] = "false"
         logger.warning("Disabling HPU graphs as they are not supported with Starcoder model!")
 
-        super(STARCODER, self).__init__(
+        super(StarCoder, self).__init__(
             model_id=model_id,
             revision=revision,
             dtype=dtype,

--- a/server/text_generation_server/models/starcoder.py
+++ b/server/text_generation_server/models/starcoder.py
@@ -1,3 +1,4 @@
+from loguru import logger
 import torch
 from dataclasses import dataclass
 from typing import List, Optional, Type
@@ -38,6 +39,10 @@ class STARCODER(CausalLM):
             revision=revision,
             dtype=dtype,
         )
+
+        # Bypasses runtime error "Empty tensor optional" with hpu graphs
+        self.enable_hpu_graph = False
+        logger.warning("Disabling HPU graphs as they are not supported with Starcoder model!")
 
     @property
     def batch_type(self) -> Type[CausalLMBatch]:


### PR DESCRIPTION
# What does this PR do?


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #116
@OlivierDehaene , @Narsil 
- For this PR , with tgi-gaudi 1.14.0 container built from main I noticed I have to set `ENABLE_HPU_GRAPH=False` for `bigcode/starcoder`  otherwise I see error 
     ```
    <snip>
    DEBUG text_generation_launcher:     _, decode_batch = self.generate_token([prefill_batch])
    DEBUG text_generation_launcher:   File "/usr/lib/python3.10/contextlib.py", line 79, in inner
    DEBUG text_generation_launcher:     return func(*args, **kwds)
    DEBUG text_generation_launcher:   File "/usr/local/lib/python3.10/dist-packages/text_generation_server/models/causal_lm.py", line 951, in generate_token
    DEBUG text_generation_launcher:     batch.logits = self.forward(
    DEBUG text_generation_launcher:   File "/usr/local/lib/python3.10/dist-packages/text_generation_server/models/causal_lm.py", line 838, in forward
    DEBUG text_generation_launcher:     return self.model.forward(**kwargs)
    DEBUG text_generation_launcher:   File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/hpu/graphs.py", line 661, in forward
    DEBUG text_generation_launcher:     return wrapped_hpugraph_forward(cache, stream, orig_fwd, args, kwargs, disable_tensor_cache, asynchronous, dry_run, max_graphs)
    DEBUG text_generation_launcher:   File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/hpu/graphs.py", line 545, in wrapped_hpugraph_forward
    DEBUG text_generation_launcher:     graph.capture_end()
    DEBUG text_generation_launcher:   File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/hpu/graphs.py", line 41, in capture_end
    DEBUG text_generation_launcher:     _hpu_C.capture_end(self.hpu_graph)
    DEBUG text_generation_launcher: RuntimeError: Empty tensor optional
    ```
- If I build with `vault.habana.ai/gaudi-docker/1.15.0/ubuntu22.04/habanalabs/pytorch-installer-2.2.0:latest`, I see a new error `GPTBigCodeSdpaAttention.forward() got an unexpected keyword argument 'token_idx'`
- I can recreate the issue with this code snippet on the same tgi-gaudi container:
  ```
   import torch
   import habana_frameworks.torch as ht

   g = ht.hpu.HPUGraph()
   s = ht.hpu.Stream()

   with ht.hpu.stream(s):
       g.capture_begin()
       a = torch.full((100,), 1, device="hpu")
       b = a
       b = b + 1
       g.capture_end()

   g.replay()
   ht.hpu.synchronize()
  ```
   fails with
  ```
   Exception ignored in: <function HPUGraph.__del__ at 0x7f2e140c3d90>
   Traceback (most recent call last):
     File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/hpu/graphs.py", line 104, in __del__
     File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/hpu/graphs.py", line 101, in reset
   TypeError: 'NoneType' object is not callable
  ```
   but passes in following docker container with 
   ```
    Docker version : 1.15.0,  pt_version: PyTorch version : 2.2.0,  build_version: Build version :489
   ```

Not sure if its an issue resolved in 1.15.0 or the rootcause is mismatch of docker (1.14.0) vs host (1.15.0)
Host configuration
```
HL-SMI Version:                              hl-1.15.0-fw-48.2.1.1         
Driver Version:                                     1.15.0-a596ef0   
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests? TODO


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
