### PR TITLE
Fix to server models unit tests so they run in EAGER mode

### DIFF
--- a/server/tests/models/test_causal_lm.py
+++ b/server/tests/models/test_causal_lm.py
@@ -95,7 +95,7 @@ def test_batch_from_pb(default_pb_batch, default_causal_lm_batch):
     assert batch.past_key_values is None
     assert all(
         [
-            torch.equal(input_ids, request.all_input_ids[:batch.input_length + 1, 0])
+            torch.equal(input_ids.to('cpu'), request.all_input_ids[:batch.input_length + 1, 0])
             for input_ids, request in zip(batch.input_ids, batch.requests)
         ]
     )

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -64,7 +64,7 @@ def round_up(number, k):
 
 
 def to_tensor_indices(indices, device):
-    return torch.tensor(indices, dtype=torch.int32, device=device)
+    return torch.tensor(indices, dtype=torch.long, device=device)
 
 
 def calculate_chunks(offset):


### PR DESCRIPTION
This PR is introducing little fixes so server/models/test_causal_lm.py  can work in EAGER mode.

To run mentioned unit tests in eager mode:
```bash
ENABLE_HPU_GRAPH=false PT_HPU_LAZY_MODE=0 HUGGING_FACE_HUB_TOKEN=<your HF token> HF_HUB_ENABLE_HF_TRANSFER=1 pytest -s -vv  server/tests/models/test_causal_lm.py
```
