### PR TITLE
Pad next token chooser parameters with empty logits processors

### DIFF
--- a/server/text_generation_server/utils/__init__.py
+++ b/server/text_generation_server/utils/__init__.py
@@ -22,7 +22,8 @@ from text_generation_server.utils.tokens import (
     Sampling,
     Greedy,
     make_tokenizer_optional,
-    is_tokenizer_transparent
+    is_tokenizer_transparent,
+    pad_next_token_chooser_parameters,
 )
 
 __all__ = [

--- a/server/text_generation_server/utils/tokens.py
+++ b/server/text_generation_server/utils/tokens.py
@@ -504,6 +504,30 @@ class HeterogeneousNextTokenChooser:
         )
 
 
+def pad_next_token_chooser_parameters(
+    parameters: List[generate_pb2.NextTokenChooserParameters],
+    expected_size: int,
+) -> List[generate_pb2.NextTokenChooserParameters]:
+    # disable all logits processors to minimize padding overhead
+    empty_parameters = generate_pb2.NextTokenChooserParameters(
+        temperature=1.0,
+        top_k=0,
+        top_p=1.0,
+        typical_p=1.0,
+        do_sample=False,
+        seed=0,
+        repetition_penalty=1.0,
+        frequency_penalty=0.0,
+        watermark=False,
+        grammar="",
+        grammar_type=0,
+    )
+    parameters.extend(
+        [empty_parameters] * (expected_size - len(parameters))
+    )
+    return parameters
+
+
 class Sampling:
     def __init__(self, seed: int, device: str = "cpu"):
         self.generator = torch.Generator("cpu")


### PR DESCRIPTION
# What does this PR do?

Fixes performance issue while padding next token chooser parameters. Some of the logits processor were active by default for dummy requests what causes unnecessary host overhead for higher batch sizes, especially if most of requests were dummy at the moment.
