### PR TITLE
Upgrade tokenizers version from 0.14.0 to 0.19.0 in benchmark

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1.0"
 tabled = "0.14.0"
 text-generation-client = { path = "../router/client" }
 thiserror = "1.0.48"
-tokenizers = { version = "0.14.0", features = ["http"] }
+tokenizers = { version = "0.19.0", features = ["http"] }
 tokio = { version = "1.32.0", features = ["rt", "rt-multi-thread", "parking_lot", "signal", "sync", "macros"] }
 tui = {package = "ratatui", version = "0.23", default-features = false, features = ["crossterm"]}
 tracing = "0.1.37"


### PR DESCRIPTION
# What does this PR do?
The current tokenizers version in benchmark doesn't support the model, mistralai/Mistral-7B-v0.3. 
The error message is 
_thread 'main' panicked at benchmark/src/main.rs:159:78:
called `Result::unwrap()` on an `Err` value: Error("data did not match any variant of untagged enum PreTokenizerWrapper", line: 6952, column: 3)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Aborted (core dumped)_

After upgrading tokenizer to 0.19.0, the issue is resolved. As a result, suggest upgrading tokenizer to support the model new version. 


Fixes # (issue)
text-generation-benchmark failed to execute with the model, mistralai/Mistral-7B-v0.3. 
