### PR TITLE
[Torch.compile] Enable llama-2-7b

### DIFF
--- a/server/tests/models/test_causal_lm.py
+++ b/server/tests/models/test_causal_lm.py
@@ -95,7 +95,7 @@ def test_batch_from_pb(default_pb_batch, default_causal_lm_batch):
     assert batch.past_key_values is None
     assert all(
         [
-            torch.equal(input_ids, request.all_input_ids[:batch.input_length + 1, 0])
+            torch.equal(input_ids.to('cpu'), request.all_input_ids[:batch.input_length + 1, 0])
             for input_ids, request in zip(batch.input_ids, batch.requests)
         ]
     )

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -839,7 +839,6 @@ class CausalLM(Model):
             "attention_mask": attention_mask,
             "past_key_values": past_key_values,
             "token_idx": token_idx,
-            "lazy_mode": LAZY_MODE == 1,
         }
 
         if self.has_position_ids:

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -65,6 +65,7 @@ def torch_compile_for_eager(func):
         return func
     return torch.compile(func, backend="hpu_backend", options={"keep_input_mutations": True})
 
+
 def round_up(number, k):
     return (number + k - 1) // k * k
 
@@ -89,6 +90,7 @@ def biggest_single_chunk(offset):
         return int(math.copysign(CHUNK_SIZES[idx - 1], offset))
     else:
         return 0
+
 
 @torch_compile_for_eager
 def grouped_pad(tensor_groups, dims, values):
@@ -652,7 +654,7 @@ class CausalLM(Model):
             if LAZY_MODE == 0: 
                 # It is said that "keep_input_mutations" is safe for inference to be done
                 dbg_trace(
-                    "FWD", f'Torch compiling of model')
+                    "TORCH COMPILE", f'Torch compiling of model')
                 model.model = torch.compile(model.model, backend="hpu_backend", options={"keep_input_mutations": True})
 
         model = self.setup_quantization(model)

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -84,7 +84,7 @@ def biggest_single_chunk(offset):
     else:
         return 0
 
-
+@torch.compile(backend = "hpu_backend", options={"keep_input_mutations": True}) # TODO: not for lazy
 def grouped_pad(tensor_groups, dims, values):
     grouped_result = []
     for tensors, dim, value in zip(tensor_groups, dims, values):
@@ -100,6 +100,7 @@ def grouped_pad(tensor_groups, dims, values):
     return grouped_result
 
 
+@torch.compile(backend = "hpu_backend", options={"keep_input_mutations": True}) # TODO: not for lazy
 def roll(tensor, chunk, dim, merge_graphs):
     if dim is None:
         return tensor
@@ -109,6 +110,7 @@ def roll(tensor, chunk, dim, merge_graphs):
     return tensor
 
 
+@torch.compile(backend = "hpu_backend", options={"keep_input_mutations": True}) # TODO: not for lazy
 def grouped_roll(tensor_groups, chunk, dims, merge_graphs):
     tensor_groups = [[roll(t, chunk, dim, merge_graphs) for t in tensors] for tensors, dim in zip(tensor_groups, dims)]
     if merge_graphs:
@@ -116,6 +118,7 @@ def grouped_roll(tensor_groups, chunk, dims, merge_graphs):
     return tensor_groups
 
 
+@torch.compile(backend = "hpu_backend", options={"keep_input_mutations": True}) # TODO: not for lazy
 def grouped_shift(tensor_groups, dims, offset, merge_graphs):
     chunks = calculate_chunks(offset)
     for c in chunks:
@@ -123,6 +126,7 @@ def grouped_shift(tensor_groups, dims, offset, merge_graphs):
     return tensor_groups
 
 
+@torch.compile(backend = "hpu_backend", options={"keep_input_mutations": True}) # TODO: not for lazy
 def move(dst_tensors, dst_indices, src_tensors):
     bs_dim = 0
     num_indices = dst_indices.size(0)
@@ -138,12 +142,14 @@ def grouped_move(dst_tensor_groups, dst_indices, src_tensor_groups):
         move(dst_tensors, dst_indices, src_tensors)
 
 
+@torch.compile(backend = "hpu_backend", options={"keep_input_mutations": True}) # TODO: not for lazy
 def extend_tensor(tensor, padding, dim):
     result = torch.cat([tensor, padding], dim=dim)
     htorch.core.mark_step()
     return result
 
 
+@torch.compile(backend = "hpu_backend", options={"keep_input_mutations": True}) # TODO: not for lazy
 def extend_batch(tensors, target_bs, dim):
     diff = target_bs - tensors[0].size(dim)
     # TODO: add support for shrinking bs
@@ -161,12 +167,14 @@ def grouped_extend_batch(tensor_groups, target_bs, bs_dims):
     return tensor_groups
 
 
+@torch.compile(backend = "hpu_backend", options={"keep_input_mutations": True}) # TODO: not for lazy
 def merge(tensor_group):
     tensor_group = [torch.stack(tensor_group)]
     htorch.core.mark_step()
     return tensor_group
 
 
+@torch.compile(backend = "hpu_backend", options={"keep_input_mutations": True}) # TODO: not for lazy
 def split(tensor_group, clone_data):
     tensor_group = [t.squeeze(0) for t in torch.split(tensor_group[0], 1)]
     if clone_data:

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -482,7 +482,6 @@ class CausalLMBatch(Batch):
             tokenizer=tokenizer,
             quantization_enabled=hq_env.is_quantization_enabled,
         )
-#        import pdb;pdb.set_trace()
         tokenized_inputs = tokenizer(
             [r.data.inputs for r in requests] + dummy_inputs,
             return_tensors="pt",
@@ -652,6 +651,8 @@ class CausalLM(Model):
         else:
             if LAZY_MODE == 0: 
                 # It is said that "keep_input_mutations" is safe for inference to be done
+                dbg_trace(
+                    "FWD", f'Torch compiling of model')
                 model.model = torch.compile(model.model, backend="hpu_backend", options={"keep_input_mutations": True})
 
         model = self.setup_quantization(model)
@@ -843,9 +844,6 @@ class CausalLM(Model):
 
         if bypass_hpu_graph != None:
             kwargs["bypass_hpu_graphs"] = bypass_hpu_graph
-
-        dbg_trace(
-            "FWD", f'bypass_hpu_graph:{bypass_hpu_graph}')
 
         kwargs.update(self.kwargs)
         if past_key_values is not None:


### PR DESCRIPTION
This set of changes are enabling torch compiled version of llama-2-7-b.

**Notes:**
- It works starting with  current release (1.16)
- Lazy mode of llama-2-7b still works
- Apart from unit tests , I compared output from actual service which was on par with lazy mode
- Performance (very limited perf testing was done) was slightly lower than for lazy mode 

**Running unit test for torch compiled mode:**
```bash
ENABLE_HPU_GRAPH=false PT_HPU_LAZY_MODE=0 python -m pytest -s -vv server/tests/models/test_causal_lm.py
```

**Running unit test for  lazy mode:**
```bash
python -m pytest -s -vv server/tests/models/test_causal_lm.py
```

**How to check if torch compile is used?:**
- Prepand env var TORCH_LOGS:
```bash
  TORCH_LOGS='dynamo' ENABLE_HPU_GRAPH=false PT_HPU_LAZY_MODE=0 python -m pytest -s -vv server/tests/models/test_causal_lm.py
```
![image](https://github.com/huggingface/tgi-gaudi/assets/15085062/89d9a954-3947-445a-b019-6faf7daa47be)

@kdamaszk , @jkaniecki Please review