### PR TITLE
[Torch Compile]Fix to perf regression caused by OH update

### DIFF
--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -850,6 +850,7 @@ class CausalLM(Model):
             "attention_mask": attention_mask,
             "past_key_values": past_key_values,
             "token_idx": token_idx,
+            "lazy_mode": LAZY_MODE == 1,
         }
 
         if self.has_position_ids:


### PR DESCRIPTION
This is a fix to perf regression in Torch compiled causal models introduced by update of Optiumum Habana. Optimum Habana introduce a path suitable for torch compile and a path for lazy. This paths are now to be choses with lazy_mode kwarg and this lazy_mode was set to True by default in OH 1.11.1 , so for Torch compile we had to switch this lazy_mode to False.

@kdamaszk Please review