### PR TITLE
Clear previous hpu_graphs when graph shape changed to save memory

### DIFF
--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -602,6 +602,7 @@ class CausalLM(Model):
         dtype: Optional[torch.dtype] = None,
         trust_remote_code: bool = False,
     ):
+        self.prev_bs = 0
         if use_medusa:
             raise RuntimeError("Medusa decoding is not enabled for AutoModel")
 
@@ -961,6 +962,9 @@ class CausalLM(Model):
             batch = batch.__class__.recombine([batch], self.tokenizer.pad_token_id)
 
         scenario = 'PREFILL' if prefill else 'GENERATE'
+        if batch.batch_size != self.prev_bs:
+            self.model.clear_cache()
+            self.prev_bs = batch.batch_size
         dbg_trace(
             scenario, f'bs:{batch.batch_size} num_reqs:{len(batch.requests)} seq_len:{batch.seq_length} padding:{batch.right_padding}')
         assert batch.right_padding > 0, 'No more room for next token!'

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -962,7 +962,7 @@ class CausalLM(Model):
             batch = batch.__class__.recombine([batch], self.tokenizer.pad_token_id)
 
         scenario = 'PREFILL' if prefill else 'GENERATE'
-        if batch.batch_size != self.prev_bs:
+        if self.enable_hpu_graph and batch.batch_size != self.prev_bs:
             self.model.clear_cache()
             self.prev_bs = batch.batch_size
         dbg_trace(


### PR DESCRIPTION
# What does this PR do?

Test on Llama-7b shows tgi-gaudi generates multiple hpu graphs when decoding shape changed by the increasing bs. On bf16 dtype, 128in 1024out scenario, the maximum bs is 32. If we use 64 threads to send concurrent requests the server will be OOM. the and the memory status in the debug info is demonstrated in figure1 and figure 2 respectively. Every graph keeps a copy of kv cache, thus occupy a large part of the total memory.
![image](https://github.com/huggingface/tgi-gaudi/assets/83266045/4d823ed1-7512-40ad-96a1-101f6cd97c20)
![image](https://github.com/huggingface/tgi-gaudi/assets/83266045/6e2137b2-9a4e-49bf-99f8-c9160011f20a)

Since the previous graph won't be used again as the bs won't shrink in the `recombine` function, we propose to record the current bs and remove previous graphs when bs changes to save memory. With this PR, on Llama7b 128in 1024out bf16 scenario, the max bs can increase to 64. The memory usage of bs32 and bs64 is listed  below. 
![image](https://github.com/huggingface/tgi-gaudi/assets/83266045/593c1601-9969-4127-b1f7-e8081f0c6799)
![image](https://github.com/huggingface/tgi-gaudi/assets/83266045/e9afbaa3-a9ef-4543-86be-2906cf3b97f0)


Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
