### PR TITLE
Avoid GC during runtime when input seq len is exact --max-input-length

### DIFF
--- a/router/client/src/client.rs
+++ b/router/client/src/client.rs
@@ -137,8 +137,8 @@ impl Client {
         let seq_bucket_size: u32 = read_env_var("PAD_SEQUENCE_TO_MULTIPLE_OF", 128);
         let mut seq_lengths: Vec<u32> = (seq_bucket_size..max_input_length+1).step_by(seq_bucket_size as usize).collect();
         if let Some(&last) = seq_lengths.last() {
-            if last < max_input_length {
-                seq_lengths.push(max_input_length);
+            if last < (max_input_length + 1) {
+                seq_lengths.push(max_input_length + 1);
             }
         }
 


### PR DESCRIPTION
The original implementation can fit (bucket_size - 1) tokens in a bucket because the last one is saved as a placeholder for output. 
For example, when --max-input-len=32000 and PAD_SEQUENCE_TO_MULTIPLE_OF=2000, warmup is done up to 31999. Thus, when a request's input seq len is 32000, it will cause another GC and performance degradation.

This PR creates another bucket that can cover a request with the seq len same as --max-input-len.

For Mistral model with --max-input-len=32000, bucket size=2000

![image](https://github.com/huggingface/tgi-gaudi/assets/29113514/cc405fad-d768-4d8e-be9e-daafe520d88b)



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
