### PR TITLE
Do not schedule decode if max_new_tokens is equal to 1

### DIFF
--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -981,6 +981,10 @@ class CausalLM(Model):
                 batch.past_key_values,
                 bypass_hpu_graph=prefill and self.limit_hpu_graph if self.enable_hpu_graph else None,
             )
+        elif all([req.stopping_criteria.max_new_tokens == 1 for req in batch.requests]):
+            # Don't schedule next forward if max_new_tokens for all requests equals 1 
+            # - we've already generated the first and only needed token in the prefill phase
+            pass
         else:
             token_idx = torch.tensor(batch.attention_mask.shape[-1] - batch.right_padding).to(self.device)
             input_ids = torch.index_select(batch.input_ids, 1, token_idx - 1)


### PR DESCRIPTION
# What does this PR do?

This is a small change requested by @kdamaszk. Instead of always scheduling the next forward, we first check if it's not a prefill phase and all requests in a batch have max_new_tokens == 1.  If that's the case, we skip the unnecessary forward phase, because the first and only needed tokens have already been generated in the prefill phase and are ready to be decoded.

## Who can review?

@kdamaszk 
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
