### PR TITLE
BS round up to BUCKET_SIZE to prevent capture graph when graph input not change

### DIFF
--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -966,7 +966,7 @@ class CausalLM(Model):
             batch = batch.__class__.recombine([batch], self.tokenizer.pad_token_id)
 
         scenario = 'PREFILL' if prefill else 'GENERATE'
-        if self.enable_hpu_graph and self.limit_hpu_graph and round_up(batch.batch_size,BATCH_BUCKET_SIZE) != self.prev_bs:
+        if self.enable_hpu_graph and self.limit_hpu_graph and round_up(batch.batch_size, BATCH_BUCKET_SIZE) != self.prev_bs:
             self.model.clear_cache()
             self.prev_bs = round_up(batch.batch_size, BATCH_BUCKET_SIZE)
         dbg_trace(

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -966,9 +966,9 @@ class CausalLM(Model):
             batch = batch.__class__.recombine([batch], self.tokenizer.pad_token_id)
 
         scenario = 'PREFILL' if prefill else 'GENERATE'
-        if self.enable_hpu_graph and batch.batch_size != self.prev_bs:
+        if self.enable_hpu_graph and self.limit_hpu_graph and round_up(batch.batch_size,BATCH_BUCKET_SIZE) != self.prev_bs:
             self.model.clear_cache()
-            self.prev_bs = batch.batch_size
+            self.prev_bs = round_up(batch.batch_size, BATCH_BUCKET_SIZE)
         dbg_trace(
             scenario, f'bs:{batch.batch_size} num_reqs:{len(batch.requests)} seq_len:{batch.seq_length} padding:{batch.right_padding}')
         assert batch.right_padding > 0, 'No more room for next token!'


### PR DESCRIPTION
# What does this PR do?

 1. Record rounded bs instead of actual bs to optimize decode stage with bs<BUCKET_SIZE
 2. Enable cache clearing mechanism only when `limit_hpu_graph` is enabled.

After this PR, static test won't be affected by this mechanism w/o limit_hpu_graph is enabled. Actually the "regression" mention by the issue below is basically close to the performance that `limit_hpu_graph` enabled. 

test case: llama2-7b w/ default tgi config
server command:  
```
text-generation-launcher --model-id /datasets/data/models--meta-llama--Llama-2-7b-hf/snapshots/01c7f73d771dfac7d292323805ebc428287df4f9/
```
benchmark command:
```
text-generation-benchmark -t /datasets/data/models--meta-llama--Llama-2-7b-hf/snapshots/01c7f73d771dfac7d292323805ebc428287df4f9/ 
```

Before this PR:
w/o limit hpu graph
| Step    | Batch Size | Average             | Lowest              | Highest             |
|---------|------------|---------------------|---------------------|---------------------|
| Prefill | 1          | 22.70 tokens/secs   | 17.60 tokens/secs   | 24.89 tokens/secs   |
|         | 2          | 46.98 tokens/secs   | 40.81 tokens/secs   | 49.56 tokens/secs   |
|         | 4          | 93.92 tokens/secs   | 86.73 tokens/secs   | 98.35 tokens/secs   |
|         | 8          | 1968.24 tokens/secs | 1755.59 tokens/secs | 2170.80 tokens/secs |
|         | 16         | 3317.58 tokens/secs | 3317.58 tokens/secs | 3317.58 tokens/secs |
|         | 32         | NaN tokens/secs     | NaN tokens/secs     | NaN tokens/secs     |
| Decode  | 1          | 51.33 tokens/secs   | 47.28 tokens/secs   | 52.14 tokens/secs   |
|         | 2          | 103.40 tokens/secs  | 102.19 tokens/secs  | 104.79 tokens/secs  |
|         | 4          | 207.28 tokens/secs  | 202.94 tokens/secs  | 209.85 tokens/secs  |
|         | 8          | 374.97 tokens/secs  | 373.43 tokens/secs  | 376.80 tokens/secs  |
|         | 16         | NaN tokens/secs     | NaN tokens/secs     | NaN tokens/secs     |
|         | 32         |                     |                     |                     |

w/ limit hpu graph
| Step    | Batch Size | Average            | Lowest             | Highest            |
|---------|------------|--------------------|--------------------|--------------------|
| Prefill | 1          | 26.61 tokens/secs  | 24.86 tokens/secs  | 27.94 tokens/secs  |
|         | 2          | 53.80 tokens/secs  | 51.04 tokens/secs  | 56.85 tokens/secs  |
|         | 4          | 109.19 tokens/secs | 103.74 tokens/secs | 115.45 tokens/secs |
|         | 8          | 206.79 tokens/secs | 147.34 tokens/secs | 218.68 tokens/secs |
|         | 16         | 386.79 tokens/secs | 386.79 tokens/secs | 386.79 tokens/secs |
|         | 32         | NaN tokens/secs    | NaN tokens/secs    | NaN tokens/secs    |
| Decode  | 1          | 51.77 tokens/secs  | 50.48 tokens/secs  | 52.33 tokens/secs  |
|         | 2          | 103.65 tokens/secs | 102.98 tokens/secs | 104.84 tokens/secs |
|         | 4          | 206.74 tokens/secs | 200.70 tokens/secs | 210.08 tokens/secs |
|         | 8          | 416.18 tokens/secs | 414.81 tokens/secs | 416.98 tokens/secs |
|         | 16         | NaN tokens/secs    | NaN tokens/secs    | NaN tokens/secs    |
|         | 32         |                    |                    |                    |

After this PR:
w/o limit hpu graph
| Step    | Batch Size | Average             | Lowest              | Highest             |
|---------|------------|---------------------|---------------------|---------------------|
| Prefill | 1          | 286.61 tokens/secs  | 238.61 tokens/secs  | 320.90 tokens/secs  |
|         | 2          | 605.57 tokens/secs  | 538.75 tokens/secs  | 642.42 tokens/secs  |
|         | 4          | 1125.46 tokens/secs | 846.67 tokens/secs  | 1258.16 tokens/secs |
|         | 8          | 2136.15 tokens/secs | 1925.24 tokens/secs | 2334.53 tokens/secs |
|         | 16         | 3247.96 tokens/secs | 3247.96 tokens/secs | 3247.96 tokens/secs |
|         | 32         | NaN tokens/secs     | NaN tokens/secs     | NaN tokens/secs     |
| Decode  | 1          | 49.64 tokens/secs   | 49.49 tokens/secs   | 49.91 tokens/secs   |
|         | 2          | 99.12 tokens/secs   | 98.95 tokens/secs   | 99.36 tokens/secs   |
|         | 4          | 198.70 tokens/secs  | 198.01 tokens/secs  | 200.95 tokens/secs  |
|         | 8          | 374.26 tokens/secs  | 372.57 tokens/secs  | 374.88 tokens/secs  |
|         | 16         | NaN tokens/secs     | NaN tokens/secs     | NaN tokens/secs     |
|         | 32         |                     |                     |                     |

w/ limit hpu graph
| Step    | Batch Size | Average            | Lowest             | Highest            |
|---------|------------|--------------------|--------------------|--------------------|
| Prefill | 1          | 27.10 tokens/secs  | 24.94 tokens/secs  | 28.26 tokens/secs  |
|         | 2          | 53.57 tokens/secs  | 52.34 tokens/secs  | 55.50 tokens/secs  |
|         | 4          | 103.50 tokens/secs | 80.85 tokens/secs  | 109.61 tokens/secs |
|         | 8          | 209.07 tokens/secs | 176.53 tokens/secs | 223.07 tokens/secs |
|         | 16         | 360.96 tokens/secs | 360.96 tokens/secs | 360.96 tokens/secs |
|         | 32         | NaN tokens/secs    | NaN tokens/secs    | NaN tokens/secs    |
| Decode  | 1          | 55.72 tokens/secs  | 55.37 tokens/secs  | 55.94 tokens/secs  |
|         | 2          | 111.50 tokens/secs | 111.33 tokens/secs | 111.61 tokens/secs |
|         | 4          | 222.85 tokens/secs | 222.32 tokens/secs | 223.21 tokens/secs |
|         | 8          | 416.38 tokens/secs | 415.67 tokens/secs | 416.98 tokens/secs |
|         | 16         | NaN tokens/secs    | NaN tokens/secs    | NaN tokens/secs    |
|         | 32         |                    |                    |                    |

Fixes # (issue)

#184 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@kdamaszk 