### PR TITLE
[Torch compile ] Removed redundant and crashing changes

### DIFF
--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -119,7 +119,6 @@ def roll(tensor, chunk, dim, merge_graphs):
     return tensor
 
 
-@torch_compile_for_eager
 def grouped_roll(tensor_groups, chunk, dims, merge_graphs):
     tensor_groups = [[roll(t, chunk, dim, merge_graphs) for t in tensors] for tensors, dim in zip(tensor_groups, dims)]
     if merge_graphs:
@@ -135,7 +134,6 @@ def grouped_shift(tensor_groups, dims, offset, merge_graphs):
     return tensor_groups
 
 
-@torch_compile_for_eager
 def move(dst_tensors, dst_indices, src_tensors):
     bs_dim = 0
     num_indices = dst_indices.size(0)


### PR DESCRIPTION
This PR is removing some redundant nested  torch compile execution  and also torch.compile of move function was removed as it was causing crashing of service in some situations.