### PR TITLE
Add qwen2 fp8 quant support

### DIFF
--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -692,9 +692,9 @@ class CausalLM(Model):
             "return_dict": True,
         }
 
-        if model.config.model_type in ["llama", "mistral", "starcoder2"]:
+        if model.config.model_type in ["llama", "mistral", "starcoder2", "qwen2"]:
             
-            if model.config.model_type in ["llama", "mistral"]:
+            if model.config.model_type in ["llama", "mistral", "qwen2"]:
                 kwargs["attn_softmax_bf16"] = True
                 kwargs["trim_logits"] = True
 


### PR DESCRIPTION
1. get calibration informations by optimum-habana, the average accuracy drop is 0.52% compared with bf16 model.

acc | hellaswag | lambada_openai | piqa | winogrande
-- | -- | -- | -- | --
bf16 | 0.602867955 | 0.683097225 | 0.804134929 | 0.685872139
fp8 | 0.59978092 | 0.683097225 | 0.790533188 | 0.686661405
diff | -0.51% | 0.00% | -1.69% | 0.12%
```
# measure
 QUANT_CONFIG=./quantization_config/maxabs_measure.json python  run_lm_eval.py --model_name_or_path Qwen/Qwen2-7B-Instruct --use_hpu_graphs --use_kv_cache  --batch_size 1 --bf16 --reuse_cache --use_flash_attention --flash_attention_recompute  --trim_logits --attn_softmax_bf16  --flash_attention_causal_mask -o test.json

# quant
 QUANT_CONFIG=./quantization_config/maxabs_quant.json python  run_lm_eval.py --model_name_or_path Qwen/Qwen2-7B-Instruct --use_hpu_graphs --use_kv_cache  --batch_size 1 --bf16 --reuse_cache --use_flash_attention --flash_attention_recompute  --trim_logits --attn_softmax_bf16  --flash_attention_causal_mask -o test_fp8.json
```
2. copy `hqt_output` and `maxabs_quant.json` to data and change the relative path in  `maxabs_quant.json`
```
model=Qwen/Qwen2-7B-Instruct
volume=$PWD/data
sudo docker run -it -p 8080:80 -v $volume:/data --runtime=habana -e QUANT_CONFIG=/data/maxabs_quant.json -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none -e ENABLE_HPU_GRAPH=true -e USE_FLASH_ATTENTION=true -e FLASH_ATTENTION_RECOMPUTE=true --cap-add=sys_nice --ipc=host tgi_gaudi:latest --model-id $model --max-total-tokens 2048 --max_input_tokens 1024
```

```
changwang@changwang-xxx-xxx-vm:~$ curl 127.0.0.1:8080/generate   -X POST   -d '{"inputs":"What is Deep Learning?","parameters":{"max_new_tokens":32}}'   -H 'Content-Type: application/json'
 
{"generated_text":" Deep learning is a subset of machine learning that uses artificial neural networks to model and solve complex problems. It is called \"deep\" because the neural networks have multiple"}

```

```