### PR TITLE
Make prefill time of static benchmark correct

### DIFF
--- a/benchmark/src/generation.rs
+++ b/benchmark/src/generation.rs
@@ -163,7 +163,10 @@ async fn prefill(
 
     // Run prefill
     let start_time = Instant::now();
+
     let (_, decode_batch, _) = client.prefill(batch.clone()).await?;
+
+    let (_, decode_batch, _) = client.decode(vec![decode_batch.clone().unwrap()]).await?;
 
     // Get latency
     let latency = start_time.elapsed();
@@ -180,11 +183,12 @@ async fn prefill(
     };
 
     Ok((step, decode_batch))
+
 }
 
 /// Run a full decode
 async fn decode(batch: CachedBatch, client: &mut ShardedClient) -> Result<Decode, ClientError> {
-    let mut decode_length = 0;
+    let mut decode_length = 1; // 1 decode step was already scheduled in prefill with speculative scheduling
     let batch_size = batch.size;
 
     let start_time = Instant::now();

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -51,7 +51,7 @@ struct Args {
     runs: usize,
 
     /// Number of warmup cycles
-    #[clap(default_value = "1", short, long, env)]
+    #[clap(default_value = "3", short, long, env)]
     warmups: usize,
 
     /// The location of the grpc socket. This benchmark tool bypasses the router

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -33,7 +33,6 @@ from transformers import (
 
 from text_generation_server.utils.tokens import batch_top_tokens
 from text_generation_server.models import Model
-from text_generation_server.utils.tokens import batch_top_tokens
 from text_generation_server.models.types import (
     Batch,
     Tokens,


### PR DESCRIPTION
In the original code, the TTFT was inaccurate because it was returned only after the prefill was scheduled but before the generation result is returned due to the speculative scheduling. This change ensures the timer waits until the prefill result is returned.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?